### PR TITLE
Modify isArbitraryWeight to be consistent with the implementation of tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,7 +546,7 @@ A brief summary for each validator:
 -   `isArbitrarySize` checks whether class part is an arbitrary value which starts with `size:` (`[size:200px_100px]`) which is necessary for background-size classNames.
 -   `isArbitraryPosition` checks whether class part is an arbitrary value which starts with `position:` (`[position:200px_100px]`) which is necessary for background-position classNames.
 -   `isArbitraryUrl` checks whether class part is an arbitrary value which starts with `url:` or `url(` (`[url('/path-to-image.png')]`, `url:var(--maybe-a-url-at-runtime)]`) which is necessary for background-image classNames.
--   `isArbitraryWeight` checks whether class part is an arbitrary value which starts with `weight:` or is a number (`[weight:var(--value)]`, `[450]`) which is necessary for font-weight classNames.
+-   `isArbitraryWeight` checks whether class part is an arbitrary value which starts with `number:` or is a number (`[number:var(--value)]`, `[450]`) which is necessary for font-weight classNames.
 -   `isArbitraryShadow` checks whether class part is an arbitrary value which starts with the same pattern as a shadow value (`[0_35px_60px_-15px_rgba(0,0,0,0.3)]`), namely with two lengths separated by a underscore.
 -   `isAny` always returns true. Be careful with this validator as it might match unwanted classes. I use it primarily to match colors or when I'm certain there are no other class groups in a namespace.
 

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -49,7 +49,7 @@ export function isArbitraryWeight(classPart: string) {
     const arbitraryValue = arbitraryValueRegex.exec(classPart)?.[1]
 
     return arbitraryValue
-        ? !Number.isNaN(Number(arbitraryValue)) || arbitraryValue.startsWith('weight:')
+        ? !Number.isNaN(Number(arbitraryValue)) || arbitraryValue.startsWith('number:')
         : false
 }
 

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -144,9 +144,9 @@ describe('validators', () => {
     })
 
     test('isArbitraryWeight', () => {
-        expect(isArbitraryWeight('[weight:black]')).toBe(true)
-        expect(isArbitraryWeight('[weight:bla]')).toBe(true)
-        expect(isArbitraryWeight('[weight:230]')).toBe(true)
+        expect(isArbitraryWeight('[number:black]')).toBe(true)
+        expect(isArbitraryWeight('[number:bla]')).toBe(true)
+        expect(isArbitraryWeight('[number:230]')).toBe(true)
         expect(isArbitraryWeight('[450]')).toBe(true)
 
         expect(isArbitraryWeight('[2px]')).toBe(false)


### PR DESCRIPTION
font-weight arbitrary value prefix is 'number:' in tailwind implementation.
see: https://github.com/tailwindlabs/tailwindcss/blob/f2d73b8c3d6f028680bd0b6239102be231b4ff46/tests/arbitrary-values.test.css#L795