### PR TITLE
Optimize runtime performance by using Map

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
         "version": "zx scripts/update-readme.js",
         "postversion": "if [ -n \"$DANYS_MACHINES\" ]; then git push --follow-tags && open https://github.com/dcastil/tailwind-merge/releases; fi"
     },
-    "dependencies": {
-        "hashlru": "^2.3.0"
-    },
     "devDependencies": {
         "@size-limit/preset-small-lib": "^7.0.8",
         "@types/jest": "^27.4.1",
@@ -61,7 +58,7 @@
         "prettier": "^2.6.2",
         "size-limit": "^7.0.8",
         "ts-jest": "^27.1.4",
-        "typescript": "^4.6.3",
+        "typescript": "^4.7.4",
         "zx": "^6.1.0"
     },
     "size-limit": [

--- a/src/lib/class-utils.ts
+++ b/src/lib/class-utils.ts
@@ -1,7 +1,7 @@
 import { ClassGroupId, Config, ClassGroup, ClassValidator, ThemeObject, ThemeGetter } from './types'
 
 export interface ClassPartObject {
-    nextPart: Record<string, ClassPartObject>
+    nextPart: Map<string, ClassPartObject>
     validators: ClassValidatorObject[]
     classGroupId?: ClassGroupId
 }
@@ -46,7 +46,7 @@ function getGroupRecursive(
     }
 
     const currentClassPart = classParts[0]!
-    const nextClassPartObject = classPartObject.nextPart[currentClassPart]
+    const nextClassPartObject = classPartObject.nextPart.get(currentClassPart)
     const classGroupFromNextClassPart = nextClassPartObject
         ? getGroupRecursive(classParts.slice(1), nextClassPartObject)
         : undefined
@@ -87,7 +87,7 @@ function getGroupIdForArbitraryProperty(className: string) {
 export function createClassMap(config: Config) {
     const { theme, prefix } = config
     const classMap: ClassPartObject = {
-        nextPart: {},
+        nextPart: new Map<string, ClassPartObject>(),
         validators: [],
     }
 
@@ -151,14 +151,14 @@ function getPart(classPartObject: ClassPartObject, path: string) {
     let currentClassPartObject = classPartObject
 
     path.split(CLASS_PART_SEPARATOR).forEach((pathPart) => {
-        if (currentClassPartObject.nextPart[pathPart] === undefined) {
-            currentClassPartObject.nextPart[pathPart] = {
-                nextPart: {},
+        if (!currentClassPartObject.nextPart.has(pathPart)) {
+            currentClassPartObject.nextPart.set(pathPart, {
+                nextPart: new Map(),
                 validators: [],
-            }
+            })
         }
 
-        currentClassPartObject = currentClassPartObject.nextPart[pathPart]!
+        currentClassPartObject = currentClassPartObject.nextPart.get(pathPart)!
     })
 
     return currentClassPartObject

--- a/src/lib/config-utils.ts
+++ b/src/lib/config-utils.ts
@@ -6,7 +6,7 @@ export type ConfigUtils = ReturnType<typeof createConfigUtils>
 
 export function createConfigUtils(config: Config) {
     return {
-        cache: getLruCache<string>(config.cacheSize),
+        cache: getLruCache<string, string>(config.cacheSize),
         ...createClassUtils(config),
     }
 }

--- a/src/lib/lru-cache.ts
+++ b/src/lib/lru-cache.ts
@@ -7,7 +7,7 @@ export interface LruCache<Key, Value> {
 
 // LRU cache inspired from hashlru (https://github.com/dominictarr/hashlru/blob/v1.0.4/index.js) but object replaced with Map to improve performance
 export function getLruCache<Key, Value>(maxCacheSize: number): LruCache<Key, Value> {
-    if (maxCacheSize <= 0) {
+    if (maxCacheSize < 1) {
         return {
             get: () => undefined,
             set: () => {},

--- a/src/lib/lru-cache.ts
+++ b/src/lib/lru-cache.ts
@@ -1,19 +1,52 @@
-import HLRU from 'hashlru'
-
 // Export is needed because TypeScript complains about an error otherwise:
 // Error: …/tailwind-merge/src/config-utils.ts(8,17): semantic error TS4058: Return type of exported function has or is using name 'LruCache' from external module "…/tailwind-merge/src/lru-cache" but cannot be named.
-export interface LruCache<T> {
-    get(key: string): T | undefined
-    set(key: string, value: T): void
+export interface LruCache<Key, Value> {
+    get(key: Key): Value | undefined
+    set(key: Key, value: Value): void
 }
 
-export function getLruCache<T>(cacheSize: number): LruCache<T> {
-    if (cacheSize >= 1) {
-        return HLRU(cacheSize)
+// LRU cache inspired from hashlru (https://github.com/dominictarr/hashlru/blob/v1.0.4/index.js) but object replaced with Map to improve performance
+export function getLruCache<Key, Value>(maxCacheSize: number): LruCache<Key, Value> {
+    if (maxCacheSize <= 0) {
+        return {
+            get: () => undefined,
+            set: () => {},
+        }
+    }
+
+    let cacheSize = 0
+    let cache = new Map<Key, Value>()
+    let previousCache = new Map<Key, Value>()
+
+    function update(key: Key, value: Value) {
+        cache.set(key, value)
+        cacheSize++
+
+        if (cacheSize > maxCacheSize) {
+            cacheSize = 0
+            previousCache = cache
+            cache = new Map()
+        }
     }
 
     return {
-        get: () => undefined,
-        set: () => {},
+        get(key) {
+            let value = cache.get(key)
+
+            if (value !== undefined) {
+                return value
+            }
+            if ((value = previousCache.get(key)) !== undefined) {
+                update(key, value)
+                return value
+            }
+        },
+        set(key, value) {
+            if (cache.has(key)) {
+                cache.set(key, value)
+            } else {
+                update(key, value)
+            }
+        },
     }
 }

--- a/tests/class-map.test.ts
+++ b/tests/class-map.test.ts
@@ -5,12 +5,10 @@ test('class map has correct class groups at first part', () => {
     const classMap = createClassMap(getDefaultConfig())
 
     const classGroupsByFirstPart = Object.fromEntries(
-        Object.keys(classMap.nextPart)
-            .sort()
-            .map((key) => [
-                key,
-                Array.from(getClassGroupsInClassPart(classMap.nextPart[key]!)).sort(),
-            ])
+        Array.from(classMap.nextPart.entries()).map(([key, value]) => [
+            key,
+            Array.from(getClassGroupsInClassPart(value)).sort(),
+        ])
     )
 
     expect(classMap.classGroupId).toBeUndefined()
@@ -258,7 +256,7 @@ function getClassGroupsInClassPart(classPart: ClassPartObject): Set<string> {
 
     validators.forEach((validator) => classGroups.add(validator.classGroupId))
 
-    Object.values(nextPart).forEach((nextClassPart) => {
+    nextPart.forEach((nextClassPart) => {
         getClassGroupsInClassPart(nextClassPart).forEach((classGroup) => {
             classGroups.add(classGroup)
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,11 +4028,6 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hashlru@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
-  integrity sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==
-
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -6549,10 +6544,10 @@ typescript@^4.5.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
JS engines assume objects are used as structs with static keys. If that assumption breaks, JS engines need to de-optimize those objects, making reading and writing of properties slower.


Therefore adding a lot of keys to an object after its creation is not ideal performance-wise. And we do a lot of it during start-up in `createClassMap` and during `twMerge` calls in `getLruCache`.

This PR attempts to improve performance by replacing those objects with Maps which are optimized for changes after its creation.

### To Dos

- [x] Test change in runtime performance in own apps