### PR TITLE
Added missing ESM `types` subpath export condition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     ],
     "source": "src/index.ts",
     "exports": {
+        "types": "./dist/index.d.ts",
         "require": "./dist/index.js",
         "import": "./dist/tailwind-merge.mjs",
         "default": "./dist/tailwind-merge.mjs"


### PR DESCRIPTION
The TypeScript 4.7 `NodeNext` module resolver does not honor the legacy `types` property in the `package.json` file.  You need to add a `types` export condition as described [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing).

> Note that the "types" condition should always come first in "exports".