### PR TITLE
Replace matchAll with exec

### DIFF
--- a/src/lib/merge-classlist.ts
+++ b/src/lib/merge-classlist.ts
@@ -74,13 +74,16 @@ export function mergeClassList(classList: string, configUtils: ConfigUtils) {
     )
 }
 
+const SPLIT_MODIFIER_REGEX = /[:[\]]/g
+
 function splitModifiers(className: string) {
     const modifiers = []
 
     let bracketDepth = 0
     let modifierStart = 0
+    let match: RegExpExecArray | null
 
-    for (const match of className.matchAll(/[:[\]]/g)) {
+    while ((match = SPLIT_MODIFIER_REGEX.exec(className))) {
         if (match[0] === ':') {
             if (bracketDepth === 0) {
                 const nextModifierStart = match.index! + 1


### PR DESCRIPTION
Closes #132

`RegExp.prototype.exec()` works for [97.38% of global users](https://caniuse.com/mdn-javascript_builtins_regexp_exec) as opposed to `String.prototype.matchAll()` which only works for [93.59% of global users](https://caniuse.com/mdn-javascript_builtins_string_matchall).