### PR TITLE
Revert "Remove ts files from npm package"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "license": "MIT",
     "author": "Dany Castillo",
     "files": [
-        "dist"
+        "dist",
+        "src"
     ],
     "source": "src/index.ts",
     "exports": {


### PR DESCRIPTION
Reverts dcastil/tailwind-merge#128, closes #136.