### PR TITLE
Fix arbitrary length `0` without unit not being recognized

### DIFF
--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -3,7 +3,7 @@ const fractionRegex = /^\d+\/\d+$/
 const stringLengths = new Set(['px', 'full', 'screen'])
 const tshirtUnitRegex = /^(\d+(\.\d+)?)?(xs|sm|md|lg|xl)$/
 const lengthUnitRegex =
-    /\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))/
+    /\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))|^0$/
 // Shadow always begins with x and y offset separated by underscore
 const shadowRegex = /^-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]+|0)/
 

--- a/tests/arbitrary-values.test.ts
+++ b/tests/arbitrary-values.test.ts
@@ -20,6 +20,11 @@ test('handles simple conflicts with arbitrary values correctly', () => {
     expect(twMerge('opacity-10 opacity-[0.025]')).toBe('opacity-[0.025]')
     expect(twMerge('scale-75 scale-[1.7]')).toBe('scale-[1.7]')
     expect(twMerge('brightness-90 brightness-[1.75]')).toBe('brightness-[1.75]')
+
+    // Handling of value `0`
+    expect(twMerge('min-h-[0.5px] min-h-[0]')).toBe('min-h-[0]')
+    expect(twMerge('text-[0.5px] text-[color:0]')).toBe('text-[0.5px] text-[color:0]')
+    expect(twMerge('text-[0.5px] text-[--my-0]')).toBe('text-[0.5px] text-[--my-0]')
 })
 
 test('handles arbitrary length conflicts with labels and modifiers correctly', () => {


### PR DESCRIPTION
Closes #234