### PR TITLE
Fix `basis-auto` and `basis-full` not being merged correctly 

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -307,7 +307,7 @@ export function getDefaultConfig() {
              * Flex Basis
              * @see https://tailwindcss.com/docs/flex-basis
              */
-            basis: [{ basis: [spacing] }],
+            basis: [{ basis: getSpacingWithAuto() }],
             /**
              * Flex Direction
              * @see https://tailwindcss.com/docs/flex-direction

--- a/tests/class-group-conflicts.test.ts
+++ b/tests/class-group-conflicts.test.ts
@@ -2,6 +2,7 @@ import { twMerge } from '../src'
 
 test('merges classes from same group correctly', () => {
     expect(twMerge('overflow-x-auto overflow-x-hidden')).toBe('overflow-x-hidden')
+    expect(twMerge('basis-full basis-auto')).toBe('basis-auto')
     expect(twMerge('w-full w-fit')).toBe('w-fit')
     expect(twMerge('overflow-x-auto overflow-x-hidden overflow-x-scroll')).toBe('overflow-x-scroll')
     expect(twMerge('overflow-x-auto hover:overflow-x-hidden overflow-x-scroll')).toBe(


### PR DESCRIPTION
Changed default config for basis so that it includes the auto class part.
Also added a test case for it.

Closes #241