### PR TITLE
docs: add tailwind-merge-go to similar packages in docs

### DIFF
--- a/docs/similar-packages.md
+++ b/docs/similar-packages.md
@@ -12,6 +12,7 @@
 -   [tailwind_merge](https://rubygems.org/gems/tailwind_merge) (Ruby)
 -   [Twix](https://hex.pm/packages/twix) (Elixir)
 -   [tailwind-merge-php](https://github.com/YieldStudio/tailwind-merge-php) (PHP)
+-   [tailwind-merge-go](https://github.com/Oudwins/tailwind-merge-go) (Golang)
 
 ---
 


### PR DESCRIPTION
Hi @dcastil,

Just adding tailwind-merge-go to similar packages which is quite close to a 1:1 port of your amazing work here!