### PR TITLE
docs: add tailwind-merge-dotnet to similar packages

### DIFF
--- a/docs/similar-packages.md
+++ b/docs/similar-packages.md
@@ -18,6 +18,7 @@
 -   [gehrisandro/tailwind-merge-php](https://packagist.org/packages/gehrisandro/tailwind-merge-php) (PHP)
 -   [tailwind-merge-laravel](https://packagist.org/packages/gehrisandro/tailwind-merge-laravel) (Laravel, PHP)
 -   [tailwind-merge-go](https://github.com/Oudwins/tailwind-merge-go) (Golang)
+-   [tailwind-merge-dotnet](https://github.com/desmondinho/tailwind-merge-dotnet) (C#)
 
 ---
 


### PR DESCRIPTION
Hi @dcastil,

I've created a [C# version](https://github.com/desmondinho/tailwind-merge-dotnet) of tailwind-merge.
In this PR I am mentioning it as the similar package in the corresponding place.

It was fun porting such a nice project! ❤️