### PR TITLE
Use arrow functions where possible to help with minification

### DIFF
--- a/src/lib/class-group-utils.ts
+++ b/src/lib/class-group-utils.ts
@@ -22,11 +22,11 @@ interface ClassValidatorObject {
 
 const CLASS_PART_SEPARATOR = '-'
 
-export function createClassGroupUtils(config: GenericConfig) {
+export const createClassGroupUtils = (config: GenericConfig) => {
     const classMap = createClassMap(config)
     const { conflictingClassGroups, conflictingClassGroupModifiers } = config
 
-    function getClassGroupId(className: string) {
+    const getClassGroupId = (className: string) => {
         const classParts = className.split(CLASS_PART_SEPARATOR)
 
         // Classes like `-inset-1` produce an empty string as first classPart. We assume that classes for negative values are used correctly and remove it from classParts.
@@ -37,10 +37,10 @@ export function createClassGroupUtils(config: GenericConfig) {
         return getGroupRecursive(classParts, classMap) || getGroupIdForArbitraryProperty(className)
     }
 
-    function getConflictingClassGroupIds(
+    const getConflictingClassGroupIds = (
         classGroupId: GenericClassGroupIds,
         hasPostfixModifier: boolean,
-    ) {
+    ) => {
         const conflicts = conflictingClassGroups[classGroupId] || []
 
         if (hasPostfixModifier && conflictingClassGroupModifiers[classGroupId]) {
@@ -56,10 +56,10 @@ export function createClassGroupUtils(config: GenericConfig) {
     }
 }
 
-function getGroupRecursive(
+const getGroupRecursive = (
     classParts: string[],
     classPartObject: ClassPartObject,
-): GenericClassGroupIds | undefined {
+): GenericClassGroupIds | undefined => {
     if (classParts.length === 0) {
         return classPartObject.classGroupId
     }
@@ -85,7 +85,7 @@ function getGroupRecursive(
 
 const arbitraryPropertyRegex = /^\[(.+)\]$/
 
-function getGroupIdForArbitraryProperty(className: string) {
+const getGroupIdForArbitraryProperty = (className: string) => {
     if (arbitraryPropertyRegex.test(className)) {
         const arbitraryPropertyClassName = arbitraryPropertyRegex.exec(className)![1]
         const property = arbitraryPropertyClassName?.substring(
@@ -103,7 +103,7 @@ function getGroupIdForArbitraryProperty(className: string) {
 /**
  * Exported for testing only
  */
-export function createClassMap(config: Config<GenericClassGroupIds, GenericThemeGroupIds>) {
+export const createClassMap = (config: Config<GenericClassGroupIds, GenericThemeGroupIds>) => {
     const { theme, prefix } = config
     const classMap: ClassPartObject = {
         nextPart: new Map<string, ClassPartObject>(),
@@ -122,12 +122,12 @@ export function createClassMap(config: Config<GenericClassGroupIds, GenericTheme
     return classMap
 }
 
-function processClassesRecursively(
+const processClassesRecursively = (
     classGroup: ClassGroup<GenericThemeGroupIds>,
     classPartObject: ClassPartObject,
     classGroupId: GenericClassGroupIds,
     theme: ThemeObject<GenericThemeGroupIds>,
-) {
+) => {
     classGroup.forEach((classDefinition) => {
         if (typeof classDefinition === 'string') {
             const classPartObjectToEdit =
@@ -166,7 +166,7 @@ function processClassesRecursively(
     })
 }
 
-function getPart(classPartObject: ClassPartObject, path: string) {
+const getPart = (classPartObject: ClassPartObject, path: string) => {
     let currentClassPartObject = classPartObject
 
     path.split(CLASS_PART_SEPARATOR).forEach((pathPart) => {
@@ -183,14 +183,13 @@ function getPart(classPartObject: ClassPartObject, path: string) {
     return currentClassPartObject
 }
 
-function isThemeGetter(func: ClassValidator | ThemeGetter): func is ThemeGetter {
-    return (func as ThemeGetter).isThemeGetter
-}
+const isThemeGetter = (func: ClassValidator | ThemeGetter): func is ThemeGetter =>
+    (func as ThemeGetter).isThemeGetter
 
-function getPrefixedClassGroupEntries(
+const getPrefixedClassGroupEntries = (
     classGroupEntries: Array<[classGroupId: string, classGroup: ClassGroup<GenericThemeGroupIds>]>,
     prefix: string | undefined,
-): Array<[classGroupId: string, classGroup: ClassGroup<GenericThemeGroupIds>]> {
+): Array<[classGroupId: string, classGroup: ClassGroup<GenericThemeGroupIds>]> => {
     if (!prefix) {
         return classGroupEntries
     }

--- a/src/lib/config-utils.ts
+++ b/src/lib/config-utils.ts
@@ -5,10 +5,8 @@ import { GenericConfig } from './types'
 
 export type ConfigUtils = ReturnType<typeof createConfigUtils>
 
-export function createConfigUtils(config: GenericConfig) {
-    return {
-        cache: createLruCache<string, string>(config.cacheSize),
-        parseClassName: createParseClassName(config),
-        ...createClassGroupUtils(config),
-    }
-}
+export const createConfigUtils = (config: GenericConfig) => ({
+    cache: createLruCache<string, string>(config.cacheSize),
+    parseClassName: createParseClassName(config),
+    ...createClassGroupUtils(config),
+})

--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -16,7 +16,7 @@ import {
     isTshirtSize,
 } from './validators'
 
-export function getDefaultConfig() {
+export const getDefaultConfig = () => {
     const colors = fromTheme('colors')
     const spacing = fromTheme('spacing')
     const blur = fromTheme('blur')

--- a/src/lib/extend-tailwind-merge.ts
+++ b/src/lib/extend-tailwind-merge.ts
@@ -5,7 +5,7 @@ import { ConfigExtension, DefaultClassGroupIds, DefaultThemeGroupIds, GenericCon
 
 type CreateConfigSubsequent = (config: GenericConfig) => GenericConfig
 
-export function extendTailwindMerge<
+export const extendTailwindMerge = <
     AdditionalClassGroupIds extends string = never,
     AdditionalThemeGroupIds extends string = never,
 >(
@@ -16,11 +16,10 @@ export function extendTailwindMerge<
           >
         | CreateConfigSubsequent,
     ...createConfig: CreateConfigSubsequent[]
-) {
-    return typeof configExtension === 'function'
+) =>
+    typeof configExtension === 'function'
         ? createTailwindMerge(getDefaultConfig, configExtension, ...createConfig)
         : createTailwindMerge(
               () => mergeConfigs(getDefaultConfig(), configExtension),
               ...createConfig,
           )
-}

--- a/src/lib/from-theme.ts
+++ b/src/lib/from-theme.ts
@@ -1,9 +1,9 @@
 import { DefaultThemeGroupIds, NoInfer, ThemeGetter, ThemeObject } from './types'
 
-export function fromTheme<
+export const fromTheme = <
     AdditionalThemeGroupIds extends string = never,
     DefaultThemeGroupIdsInner extends string = DefaultThemeGroupIds,
->(key: NoInfer<DefaultThemeGroupIdsInner | AdditionalThemeGroupIds>): ThemeGetter {
+>(key: NoInfer<DefaultThemeGroupIdsInner | AdditionalThemeGroupIds>): ThemeGetter => {
     const themeGetter = (theme: ThemeObject<DefaultThemeGroupIdsInner | AdditionalThemeGroupIds>) =>
         theme[key] || []
 

--- a/src/lib/lru-cache.ts
+++ b/src/lib/lru-cache.ts
@@ -6,7 +6,7 @@ export interface LruCache<Key, Value> {
 }
 
 // LRU cache inspired from hashlru (https://github.com/dominictarr/hashlru/blob/v1.0.4/index.js) but object replaced with Map to improve performance
-export function createLruCache<Key, Value>(maxCacheSize: number): LruCache<Key, Value> {
+export const createLruCache = <Key, Value>(maxCacheSize: number): LruCache<Key, Value> => {
     if (maxCacheSize < 1) {
         return {
             get: () => undefined,
@@ -18,7 +18,7 @@ export function createLruCache<Key, Value>(maxCacheSize: number): LruCache<Key, 
     let cache = new Map<Key, Value>()
     let previousCache = new Map<Key, Value>()
 
-    function update(key: Key, value: Value) {
+    const update = (key: Key, value: Value) => {
         cache.set(key, value)
         cacheSize++
 

--- a/src/lib/merge-classlist.ts
+++ b/src/lib/merge-classlist.ts
@@ -3,7 +3,7 @@ import { IMPORTANT_MODIFIER, sortModifiers } from './parse-class-name'
 
 const SPLIT_CLASSES_REGEX = /\s+/
 
-export function mergeClassList(classList: string, configUtils: ConfigUtils) {
+export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
     const { parseClassName, getClassGroupId, getConflictingClassGroupIds } = configUtils
 
     /**

--- a/src/lib/merge-configs.ts
+++ b/src/lib/merge-configs.ts
@@ -4,7 +4,7 @@ import { ConfigExtension, GenericConfig } from './types'
  * @param baseConfig Config where other config will be merged into. This object will be mutated.
  * @param configExtension Partial config to merge into the `baseConfig`.
  */
-export function mergeConfigs<ClassGroupIds extends string, ThemeGroupIds extends string = never>(
+export const mergeConfigs = <ClassGroupIds extends string, ThemeGroupIds extends string = never>(
     baseConfig: GenericConfig,
     {
         cacheSize,
@@ -14,7 +14,7 @@ export function mergeConfigs<ClassGroupIds extends string, ThemeGroupIds extends
         extend = {},
         override = {},
     }: ConfigExtension<ClassGroupIds, ThemeGroupIds>,
-) {
+) => {
     overrideProperty(baseConfig, 'cacheSize', cacheSize)
     overrideProperty(baseConfig, 'prefix', prefix)
     overrideProperty(baseConfig, 'separator', separator)
@@ -37,20 +37,20 @@ export function mergeConfigs<ClassGroupIds extends string, ThemeGroupIds extends
     return baseConfig
 }
 
-function overrideProperty<T extends object, K extends keyof T>(
+const overrideProperty = <T extends object, K extends keyof T>(
     baseObject: T,
     overrideKey: K,
     overrideValue: T[K] | undefined,
-) {
+) => {
     if (overrideValue !== undefined) {
         baseObject[overrideKey] = overrideValue
     }
 }
 
-function overrideConfigProperties(
+const overrideConfigProperties = (
     baseObject: Partial<Record<string, readonly unknown[]>>,
     overrideObject: Partial<Record<string, readonly unknown[]>> | undefined,
-) {
+) => {
     if (overrideObject) {
         for (const key in overrideObject) {
             overrideProperty(baseObject, key, overrideObject[key])
@@ -58,10 +58,10 @@ function overrideConfigProperties(
     }
 }
 
-function mergeConfigProperties(
+const mergeConfigProperties = (
     baseObject: Partial<Record<string, readonly unknown[]>>,
     mergeObject: Partial<Record<string, readonly unknown[]>> | undefined,
-) {
+) => {
     if (mergeObject) {
         for (const key in mergeObject) {
             const mergeValue = mergeObject[key]

--- a/src/lib/parse-class-name.ts
+++ b/src/lib/parse-class-name.ts
@@ -2,14 +2,14 @@ import { GenericConfig } from './types'
 
 export const IMPORTANT_MODIFIER = '!'
 
-export function createParseClassName(config: GenericConfig) {
+export const createParseClassName = (config: GenericConfig) => {
     const { separator, experimentalParseClassName } = config
     const isSeparatorSingleCharacter = separator.length === 1
     const firstSeparatorCharacter = separator[0]
     const separatorLength = separator.length
 
     // parseClassName inspired by https://github.com/tailwindlabs/tailwindcss/blob/v3.2.2/src/util/splitAtTopLevelOnly.js
-    function parseClassName(className: string) {
+    const parseClassName = (className: string) => {
         const modifiers = []
 
         let bracketDepth = 0
@@ -65,9 +65,7 @@ export function createParseClassName(config: GenericConfig) {
     }
 
     if (experimentalParseClassName) {
-        return function parseClassNameExperimental(className: string) {
-            return experimentalParseClassName({ className, parseClassName })
-        }
+        return (className: string) => experimentalParseClassName({ className, parseClassName })
     }
 
     return parseClassName
@@ -78,7 +76,7 @@ export function createParseClassName(config: GenericConfig) {
  * - Predefined modifiers are sorted alphabetically
  * - When an arbitrary variant appears, it must be preserved which modifiers are before and after it
  */
-export function sortModifiers(modifiers: string[]) {
+export const sortModifiers = (modifiers: string[]) => {
     if (modifiers.length <= 1) {
         return modifiers
     }

--- a/src/lib/tw-join.ts
+++ b/src/lib/tw-join.ts
@@ -29,7 +29,7 @@ export function twJoin() {
     return string
 }
 
-function toValue(mix: ClassNameArray | string) {
+const toValue = (mix: ClassNameArray | string) => {
     if (typeof mix === 'string') {
         return mix
     }

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -10,67 +10,44 @@ const shadowRegex = /^(inset_)?-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]
 const imageRegex =
     /^(url|image|image-set|cross-fade|element|(repeating-)?(linear|radial|conic)-gradient)\(.+\)$/
 
-export function isLength(value: string) {
-    return isNumber(value) || stringLengths.has(value) || fractionRegex.test(value)
-}
+export const isLength = (value: string) =>
+    isNumber(value) || stringLengths.has(value) || fractionRegex.test(value)
 
-export function isArbitraryLength(value: string) {
-    return getIsArbitraryValue(value, 'length', isLengthOnly)
-}
+export const isArbitraryLength = (value: string) =>
+    getIsArbitraryValue(value, 'length', isLengthOnly)
 
-export function isNumber(value: string) {
-    return Boolean(value) && !Number.isNaN(Number(value))
-}
+export const isNumber = (value: string) => Boolean(value) && !Number.isNaN(Number(value))
 
-export function isArbitraryNumber(value: string) {
-    return getIsArbitraryValue(value, 'number', isNumber)
-}
+export const isArbitraryNumber = (value: string) => getIsArbitraryValue(value, 'number', isNumber)
 
-export function isInteger(value: string) {
-    return Boolean(value) && Number.isInteger(Number(value))
-}
+export const isInteger = (value: string) => Boolean(value) && Number.isInteger(Number(value))
 
-export function isPercent(value: string) {
-    return value.endsWith('%') && isNumber(value.slice(0, -1))
-}
+export const isPercent = (value: string) => value.endsWith('%') && isNumber(value.slice(0, -1))
 
-export function isArbitraryValue(value: string) {
-    return arbitraryValueRegex.test(value)
-}
+export const isArbitraryValue = (value: string) => arbitraryValueRegex.test(value)
 
-export function isTshirtSize(value: string) {
-    return tshirtUnitRegex.test(value)
-}
+export const isTshirtSize = (value: string) => tshirtUnitRegex.test(value)
 
 const sizeLabels = new Set(['length', 'size', 'percentage'])
 
-export function isArbitrarySize(value: string) {
-    return getIsArbitraryValue(value, sizeLabels, isNever)
-}
+export const isArbitrarySize = (value: string) => getIsArbitraryValue(value, sizeLabels, isNever)
 
-export function isArbitraryPosition(value: string) {
-    return getIsArbitraryValue(value, 'position', isNever)
-}
+export const isArbitraryPosition = (value: string) =>
+    getIsArbitraryValue(value, 'position', isNever)
 
 const imageLabels = new Set(['image', 'url'])
 
-export function isArbitraryImage(value: string) {
-    return getIsArbitraryValue(value, imageLabels, isImage)
-}
+export const isArbitraryImage = (value: string) => getIsArbitraryValue(value, imageLabels, isImage)
 
-export function isArbitraryShadow(value: string) {
-    return getIsArbitraryValue(value, '', isShadow)
-}
+export const isArbitraryShadow = (value: string) => getIsArbitraryValue(value, '', isShadow)
 
-export function isAny() {
-    return true
-}
+export const isAny = () => true
 
-function getIsArbitraryValue(
+const getIsArbitraryValue = (
     value: string,
     label: string | Set<string>,
     testValue: (value: string) => boolean,
-) {
+) => {
     const result = arbitraryValueRegex.exec(value)
 
     if (result) {
@@ -84,21 +61,14 @@ function getIsArbitraryValue(
     return false
 }
 
-function isLengthOnly(value: string) {
+const isLengthOnly = (value: string) =>
     // `colorFunctionRegex` check is necessary because color functions can have percentages in them which which would be incorrectly classified as lengths.
     // For example, `hsl(0 0% 0%)` would be classified as a length without this check.
     // I could also use lookbehind assertion in `lengthUnitRegex` but that isn't supported widely enough.
-    return lengthUnitRegex.test(value) && !colorFunctionRegex.test(value)
-}
+    lengthUnitRegex.test(value) && !colorFunctionRegex.test(value)
 
-function isNever() {
-    return false
-}
+const isNever = () => false
 
-function isShadow(value: string) {
-    return shadowRegex.test(value)
-}
+const isShadow = (value: string) => shadowRegex.test(value)
 
-function isImage(value: string) {
-    return imageRegex.test(value)
-}
+const isImage = (value: string) => imageRegex.test(value)


### PR DESCRIPTION
This should help reduce the size of the package by using implicit returns and allow minifiers to declare multiple constants with just one const keyword.

Example:
with functions:
```js
function one(){return "1"};
function two(){return "2"};
function three(){return "3"};
```
with arrow functions:
```js
const one=()=>"1", two=()=>"2", three=()=>"3";
```