### PR TITLE
refactor(perf): reduce allocations overhead from mergeClassList

### DIFF
--- a/src/lib/merge-classlist.ts
+++ b/src/lib/merge-classlist.ts
@@ -1,8 +1,6 @@
 import { ConfigUtils } from './config-utils'
 import { IMPORTANT_MODIFIER, sortModifiers } from './parse-class-name'
 
-const SPLIT_CLASSES_REGEX = /\s+/
-
 export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
     const { parseClassName, getClassGroupId, getConflictingClassGroupIds } = configUtils
 
@@ -13,14 +11,17 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
      * @example 'hover:focus:bg-color'
      * @example 'md:!pr'
      */
-    const classGroupsInConflict = new Set<string>()
+    const classGroupsInConflict: string[] = []
+    // const classGroupsInConflict = new Set<string>()
 
+    // let result: string[] = []
     let result = ''
 
     let currentClass = ''
     for (let i = classList.length - 1; i >= 0; --i) {
         const char = classList[i]!
-        const isSpace = SPLIT_CLASSES_REGEX.test(char)
+        // more performant than Regex check - suitable for our case
+        const isSpace = char === ' '
         if (!isSpace) {
             currentClass = char + currentClass
             if (i !== 0) continue
@@ -44,6 +45,7 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
         if (!classGroupId) {
             if (!hasPostfixModifier) {
                 result = originalClassName + (result.length > 0 ? ' ' + result : result)
+                // result.push(originalClassName)
                 continue
             }
 
@@ -51,6 +53,7 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
 
             if (!classGroupId) {
                 result = originalClassName + (result.length > 0 ? ' ' + result : result)
+                // result.push(originalClassName)
                 continue
             }
 
@@ -65,21 +68,22 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
 
         const classId = modifierId + classGroupId
 
-        // [TODO]: consider using arrays
-        if (classGroupsInConflict.has(classId)) {
+        if (classGroupsInConflict.includes(classId)) {
             continue
         }
 
-        classGroupsInConflict.add(classId)
+        classGroupsInConflict.push(classId)
 
         const conflictGroups = getConflictingClassGroupIds(classGroupId, hasPostfixModifier)
         for (let i = 0; i < conflictGroups.length; ++i) {
             const group = conflictGroups[i]!
-            classGroupsInConflict.add(modifierId + group)
+            classGroupsInConflict.push(modifierId + group)
         }
 
+        // result.push(originalClassName)
         result = originalClassName + (result.length > 0 ? ' ' + result : result)
     }
 
     return result
+    // return result.join(' ')
 }

--- a/src/lib/merge-classlist.ts
+++ b/src/lib/merge-classlist.ts
@@ -12,25 +12,16 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
      * @example 'md:!pr'
      */
     const classGroupsInConflict: string[] = []
-    // const classGroupsInConflict = new Set<string>()
 
-    // let result: string[] = []
     let result = ''
 
-    let currentClass = ''
-    for (let i = classList.length - 1; i >= 0; --i) {
-        const char = classList[i]!
-        // more performant than Regex check - suitable for our case
-        const isSpace = char === ' '
-        if (!isSpace) {
-            currentClass = char + currentClass
-            if (i !== 0) continue
-        } else if (currentClass.length === 0) {
-            continue
+    for (let i = classList.length - 1; i >= 0; ) {
+        while (classList[i] === ' ') {
+            --i
         }
-
-        const originalClassName = currentClass
-        currentClass = ''
+        const nextI = classList.lastIndexOf(' ', i)
+        const originalClassName = classList.slice(nextI === -1 ? 0 : nextI + 1, i + 1)
+        i = nextI
 
         const { modifiers, hasImportantModifier, baseClassName, maybePostfixModifierPosition } =
             parseClassName(originalClassName)
@@ -45,7 +36,6 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
         if (!classGroupId) {
             if (!hasPostfixModifier) {
                 result = originalClassName + (result.length > 0 ? ' ' + result : result)
-                // result.push(originalClassName)
                 continue
             }
 
@@ -53,7 +43,6 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
 
             if (!classGroupId) {
                 result = originalClassName + (result.length > 0 ? ' ' + result : result)
-                // result.push(originalClassName)
                 continue
             }
 
@@ -80,10 +69,8 @@ export const mergeClassList = (classList: string, configUtils: ConfigUtils) => {
             classGroupsInConflict.push(modifierId + group)
         }
 
-        // result.push(originalClassName)
         result = originalClassName + (result.length > 0 ? ' ' + result : result)
     }
 
     return result
-    // return result.join(' ')
 }


### PR DESCRIPTION
This PR introduces performance optimizations to the mergeClassList function

I using plain for loop over `map,reverse,filter`. This changes should reduce memory overhead of the `mergeClassList`