### PR TITLE
fix: typo "fractons" instead of "fractions" in "stacked-fractions" class

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -727,7 +727,7 @@ export const getDefaultConfig = () => {
              * Font Variant Numeric
              * @see https://tailwindcss.com/docs/font-variant-numeric
              */
-            'fvn-fraction': ['diagonal-fractions', 'stacked-fractons'],
+            'fvn-fraction': ['diagonal-fractions', 'stacked-fractions'],
             /**
              * Letter Spacing
              * @see https://tailwindcss.com/docs/letter-spacing


### PR DESCRIPTION
Just a quick typo fix. I don't think this warrants more explanations...