### PR TITLE
add text-size to DefaultClassGroupIds

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -472,6 +472,7 @@ export type DefaultClassGroupIds =
     | 'text-decoration-thickness'
     | 'text-decoration'
     | 'text-overflow'
+    | 'text-size'
     | 'text-transform'
     | 'text-wrap'
     | 'top'


### PR DESCRIPTION
the following is valid, working code, but it type errors 

```ts
const twMerge = extendTailwindMerge({
  extend: {
    classGroups: {
      'text-size': ['text-body-md', 'text-caption-md'],
      // ^ Object literal may only specify known properties, and ''text-size'' does not exist in type 
      // 'Partial<Record<DefaultClassGroupIds, ClassGroup<DefaultThemeGroupIds>>>'.ts(2353)
      'text-color': [
        {
          'text-typography': [
            'neutral-primary',
            'neutral-secondary',
            'neutral-tertiary',
            'neutral-disabled',
            'neutral-on-color',
          ],
        },
      ],
    },
    conflictingClassGroups: {
      'text-size': [],
      // ^ Object literal may only specify known properties, and ''text-size'' does not exist in type 
      // 'Partial<Record<DefaultClassGroupIds, ClassGroup<DefaultThemeGroupIds>>>'.ts(2353)
      'text-color': [],
    },
  },
});
```