### PR TITLE
Fix doc comment being in incorrect place in default config

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -722,14 +722,14 @@ export const getDefaultConfig = () => {
             // --------------
 
             /**
-             * Width
-             * @see https://tailwindcss.com/docs/width
-             */
-            /**
              * Size
              * @see https://tailwindcss.com/docs/width#setting-both-width-and-height
              */
             size: [{ size: scaleSizing() }],
+            /**
+             * Width
+             * @see https://tailwindcss.com/docs/width
+             */
             w: [{ w: [themeContainer, 'screen', ...scaleSizing()] }],
             /**
              * Min-Width


### PR DESCRIPTION
These two docstrings are grouped together, when they should be above the relevant property.