### PR TITLE
Add support for Tailwind CSS v4.0.10

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -83,6 +83,7 @@ export const getDefaultConfig = () => {
         [
             'auto',
             { span: ['full', isInteger, isArbitraryVariable, isArbitraryValue] },
+            isInteger,
             isArbitraryVariable,
             isArbitraryValue,
         ] as const

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -79,4 +79,5 @@ test('supports Tailwind CSS v4.0 features', () => {
     expect(twMerge('font-stretch-expanded font-stretch-[66.66%] font-stretch-50%')).toBe(
         'font-stretch-50%',
     )
+    expect(twMerge('col-span-full col-2 row-span-3 row-4')).toBe('col-2 row-4')
 })


### PR DESCRIPTION
There was a new feature introduced in [Tailwind CSS v4.0.10](https://github.com/tailwindlabs/tailwindcss/releases/tag/v4.0.10):

> Add `col-<number>` and `row-<number>` utilities for grid-column and grid-row (https://github.com/tailwindlabs/tailwindcss/pull/15183)

Adding support for it here.