### PR TITLE
Fix typo in comment in types.ts

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,7 +75,7 @@ export interface ParsedClassName {
      *
      * This property is prefixed with "maybe" because tailwind-merge does not know whether something is a postfix modifier or part of the base class since it's possible to configure Tailwind CSS classes which include a `/` in the base class name.
      *
-     * If a `maybePostfixModifierPosition` is present, tailwind-merge first tries to match the `baseClassName` without the possible postfix modifier to a class group. If tht fails, it tries again with the possible postfix modifier.
+     * If a `maybePostfixModifierPosition` is present, tailwind-merge first tries to match the `baseClassName` without the possible postfix modifier to a class group. If that fails, it tries again with the possible postfix modifier.
      *
      * @example 11 // for `bg-gray-100/50`
      */


### PR DESCRIPTION
This PR fixes typo in comment. Replace from `tht` to `that`.