### PR TITLE
Fix metrics report action erroring on PRs from forks

### DIFF
--- a/.github/actions/metrics-report/package.json
+++ b/.github/actions/metrics-report/package.json
@@ -11,6 +11,7 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^6.0.0",
         "@octokit/types": "^13.8.0",
+        "@octokit/webhooks-definitions": "^3.67.3",
         "esbuild": "^0.25.0",
         "rollup": "^4.34.9"
     }

--- a/.github/actions/metrics-report/yarn.lock
+++ b/.github/actions/metrics-report/yarn.lock
@@ -274,6 +274,11 @@
   dependencies:
     "@octokit/openapi-types" "^23.0.1"
 
+"@octokit/webhooks-definitions@^3.67.3":
+  version "3.67.3"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz#d2a905a90b04af8111982d0c13658a49fc4eecb9"
+  integrity sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA==
+
 "@rollup/rollup-android-arm-eabi@4.34.9":
   version "4.34.9"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.9.tgz#661a45a4709c70e59e596ec78daa9cb8b8d27604"


### PR DESCRIPTION
E.g. happened here: https://github.com/dcastil/tailwind-merge/actions/runs/13976164737/job/39207871055

Quite annoying that external contributors always see a failed action. That should not be the case.