### PR TITLE
Fix length variable in `via-(length:*)` class being merged with `via-<color>` classes accidentally

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -112,7 +112,8 @@ export const getDefaultConfig = () => {
             ...scaleUnambiguousSpacing(),
         ] as const
     const scaleColor = () => [themeColor, isArbitraryVariable, isArbitraryValue] as const
-    const scaleGradientStopPosition = () => [isPercent, isArbitraryLength] as const
+    const scaleGradientStopPosition = () =>
+        [isPercent, isArbitraryVariableLength, isArbitraryLength] as const
     const scaleRadius = () =>
         [
             // Deprecated since Tailwind CSS v4.0.0

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -80,7 +80,10 @@ test('supports Tailwind CSS v4.0 features', () => {
         'font-stretch-50%',
     )
     expect(twMerge('col-span-full col-2 row-span-3 row-4')).toBe('col-2 row-4')
-    expect(twMerge('via-red-500 via-(length:--mobile-header-gradient-height)')).toBe(
-        'via-red-500 via-(length:--mobile-header-gradient-height)',
+    expect(twMerge('via-red-500 via-(--mobile-header-gradient)')).toBe(
+        'via-(--mobile-header-gradient)',
+    )
+    expect(twMerge('via-red-500 via-(length:--mobile-header-gradient)')).toBe(
+        'via-red-500 via-(length:--mobile-header-gradient)',
     )
 })

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -80,4 +80,7 @@ test('supports Tailwind CSS v4.0 features', () => {
         'font-stretch-50%',
     )
     expect(twMerge('col-span-full col-2 row-span-3 row-4')).toBe('col-2 row-4')
+    expect(twMerge('via-red-500 via-(length:--mobile-header-gradient-height)')).toBe(
+        'via-red-500 via-(length:--mobile-header-gradient-height)',
+    )
 })


### PR DESCRIPTION
Closes #557