### PR TITLE
Add support for tailwind CSS v4.1.5

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -782,17 +782,17 @@ export const getDefaultConfig = () => {
              * Height
              * @see https://tailwindcss.com/docs/height
              */
-            h: [{ h: ['screen', ...scaleSizing()] }],
+            h: [{ h: ['screen', 'lh', ...scaleSizing()] }],
             /**
              * Min-Height
              * @see https://tailwindcss.com/docs/min-height
              */
-            'min-h': [{ 'min-h': ['screen', 'none', ...scaleSizing()] }],
+            'min-h': [{ 'min-h': ['screen', 'lh', 'none', ...scaleSizing()] }],
             /**
              * Max-Height
              * @see https://tailwindcss.com/docs/max-height
              */
-            'max-h': [{ 'max-h': ['screen', ...scaleSizing()] }],
+            'max-h': [{ 'max-h': ['screen', 'lh', ...scaleSizing()] }],
 
             // ------------------
             // --- Typography ---

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -161,3 +161,9 @@ test('supports Tailwind CSS v4.1 features', () => {
     expect(twMerge('drop-shadow-[#123456] drop-shadow-some-color')).toBe('drop-shadow-some-color')
     expect(twMerge('drop-shadow-2xl drop-shadow-[shadow:foo]')).toBe('drop-shadow-[shadow:foo]')
 })
+
+test('supports Tailwind CSS v4.1.5 features', () => {
+    expect(twMerge('h-12 h-lh')).toBe('h-lh')
+    expect(twMerge('min-h-12 min-h-lh')).toBe('min-h-lh')
+    expect(twMerge('max-h-12 max-h-lh')).toBe('max-h-lh')
+})


### PR DESCRIPTION
Adding height-related `*-lh` utilities from https://github.com/tailwindlabs/tailwindcss/pull/17790.