### PR TITLE
Metrics report: Replace deprecated package @octokit/webhooks-definitions with @octokit/webhooks-types

### DIFF
--- a/.github/actions/metrics-report/package.json
+++ b/.github/actions/metrics-report/package.json
@@ -11,7 +11,7 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^6.0.1",
         "@octokit/types": "^15.0.0",
-        "@octokit/webhooks-definitions": "^3.67.3",
+        "@octokit/webhooks-types": "^7.6.1",
         "esbuild": "^0.25.10",
         "rollup": "^4.52.4"
     }

--- a/.github/actions/metrics-report/src/main.mjs
+++ b/.github/actions/metrics-report/src/main.mjs
@@ -12,7 +12,7 @@ run()
 
 async function run() {
     const pullRequest =
-        /** @type {import('@octokit/webhooks-definitions/schema').PullRequestEvent} */ (
+        /** @type {import('@octokit/webhooks-types').PullRequestEvent} */ (
             context.payload
         ).pull_request
 

--- a/.github/actions/metrics-report/yarn.lock
+++ b/.github/actions/metrics-report/yarn.lock
@@ -282,10 +282,10 @@
   dependencies:
     "@octokit/openapi-types" "^26.0.0"
 
-"@octokit/webhooks-definitions@^3.67.3":
-  version "3.67.3"
-  resolved "https://registry.yarnpkg.com/@octokit/webhooks-definitions/-/webhooks-definitions-3.67.3.tgz#d2a905a90b04af8111982d0c13658a49fc4eecb9"
-  integrity sha512-do4Z1r2OVhuI0ihJhQ8Hg+yPWnBYEBNuFNCrvtPKoYT1w81jD7pBXgGe86lYuuNirkDHb0Nxt+zt4O5GiFJfgA==
+"@octokit/webhooks-types@^7.6.1":
+  version "7.6.1"
+  resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz#bc96371057c2d54c982c9f8f642655b26cd588eb"
+  integrity sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==
 
 "@rollup/rollup-android-arm-eabi@4.52.4":
   version "4.52.4"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.claude/
 /.vscode/
 /dist/
 coverage


### PR DESCRIPTION
Closes https://github.com/dcastil/tailwind-merge/issues/577