### PR TITLE
fix: don't let arbitrary font-size override leading

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -925,9 +925,19 @@ export const getDefaultConfig = () => {
              * Font Size
              * @see https://tailwindcss.com/docs/font-size
              */
-            'font-size': [
-                { text: ['base', themeText, isArbitraryVariableLength, isArbitraryLength] },
-            ],
+            'font-size': [{ text: ['base', themeText] }],
+            /**
+             * Font Size with arbitrary value
+             *
+             * In contrast to the named font-size utilities (which also set a
+             * line-height), arbitrary font-size values like `text-[1.5rem]` or
+             * `text-[length:12px]` only set the `font-size` property and don't
+             * affect the line-height. They therefore must not override
+             * `leading-*` classes, so they live in their own class group.
+             * @see https://tailwindcss.com/docs/font-size
+             * @see https://github.com/dcastil/tailwind-merge/issues/573
+             */
+            'font-size-arbitrary': [{ text: [isArbitraryVariableLength, isArbitraryLength] }],
             /**
              * Font Smoothing
              * @see https://tailwindcss.com/docs/font-smoothing
@@ -2462,7 +2472,8 @@ export const getDefaultConfig = () => {
             mx: ['mr', 'ml'],
             my: ['mt', 'mb'],
             size: ['w', 'h'],
-            'font-size': ['leading'],
+            'font-size': ['font-size-arbitrary', 'leading'],
+            'font-size-arbitrary': ['font-size'],
             'fvn-normal': [
                 'fvn-ordinal',
                 'fvn-slashed-zero',
@@ -2564,6 +2575,7 @@ export const getDefaultConfig = () => {
         },
         conflictingClassGroupModifiers: {
             'font-size': ['leading'],
+            'font-size-arbitrary': ['leading'],
         },
         postfixLookupClassGroups: ['container-type'],
         orderSensitiveModifiers: [

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -333,6 +333,7 @@ export type DefaultClassGroupIds =
     | 'font-family'
     | 'font-features'
     | 'font-size'
+    | 'font-size-arbitrary'
     | 'font-smoothing'
     | 'font-stretch'
     | 'font-style'

--- a/tests/class-map.test.ts
+++ b/tests/class-map.test.ts
@@ -335,6 +335,7 @@ test('class map has correct class groups at first part', () => {
         tabular: ['fvn-spacing'],
         text: [
             'font-size',
+            'font-size-arbitrary',
             'text-alignment',
             'text-color',
             'text-overflow',

--- a/tests/conflicts-across-class-groups.test.ts
+++ b/tests/conflicts-across-class-groups.test.ts
@@ -38,3 +38,30 @@ test('line-clamp classes do create conflicts correctly', () => {
     expect(twMerge('overflow-auto inline line-clamp-1')).toBe('line-clamp-1')
     expect(twMerge('line-clamp-1 overflow-auto inline')).toBe('line-clamp-1 overflow-auto inline')
 })
+
+test('named font-size classes override leading but arbitrary ones do not', () => {
+    // Named font-size utilities set a line-height in Tailwind, so they override leading
+    expect(twMerge('leading-6 text-lg')).toBe('text-lg')
+    expect(twMerge('leading-6 text-base')).toBe('text-base')
+    expect(twMerge('text-sm leading-6 text-lg')).toBe('text-lg')
+
+    // Arbitrary font-size values only set font-size and don't affect line-height,
+    // so they must not override leading
+    expect(twMerge('leading-6 text-[1.5rem]')).toBe('leading-6 text-[1.5rem]')
+    expect(twMerge('leading-[1.75rem] text-[1.5rem]')).toBe('leading-[1.75rem] text-[1.5rem]')
+    expect(twMerge('leading-6 text-[length:12px]')).toBe('leading-6 text-[length:12px]')
+    expect(twMerge('leading-6 text-(length:--my-size)')).toBe('leading-6 text-(length:--my-size)')
+
+    // But an arbitrary font-size with a line-height modifier does set a line-height
+    // and therefore still overrides leading
+    expect(twMerge('leading-6 text-[1.5rem]/6')).toBe('text-[1.5rem]/6')
+    expect(twMerge('leading-6 text-[length:12px]/4')).toBe('text-[length:12px]/4')
+})
+
+test('named and arbitrary font-size classes still conflict with each other', () => {
+    expect(twMerge('text-lg text-[1.5rem]')).toBe('text-[1.5rem]')
+    expect(twMerge('text-[1.5rem] text-lg')).toBe('text-lg')
+    expect(twMerge('text-sm text-base')).toBe('text-base')
+    expect(twMerge('text-[1rem] text-[2rem]')).toBe('text-[2rem]')
+    expect(twMerge('text-[length:12px] text-[length:16px]')).toBe('text-[length:16px]')
+})


### PR DESCRIPTION
## Problem

`twMerge` removes preceding `leading-*` classes whenever a `text-*` font-size class follows, even when the font-size is an **arbitrary** value:

```ts
twMerge('leading-6 text-[1.5rem]')
// before: 'text-[1.5rem]'          ❌ leading-6 dropped
// after:  'leading-6 text-[1.5rem]' ✅
```

This is wrong for arbitrary values. In Tailwind, a named font-size utility like `text-lg` also sets a `line-height` (via the theme), so it legitimately overrides `leading-*`. But an arbitrary font-size like `text-[1.5rem]` / `text-[length:12px]` / `text-(length:--x)` only sets the `font-size` property and does **not** touch `line-height` — so it must not override `leading-*`.

This has been reported repeatedly: #573 (and related #446, #482, #503, #540). The maintainer noted in #573 that the behavior "indeed doesn't make sense" for arbitrary values, but that a clean default-config solution wasn't obvious.

## Fix

Split arbitrary font-size values out of the `font-size` class group into a new `font-size-arbitrary` group:

- `font-size` (named/theme: `text-base`, `text-lg`, …) still conflicts with `leading`.
- `font-size-arbitrary` (`text-[…]`, `text-(length:…)`) conflicts with `font-size` (so the two still merge with each other) but **not** with `leading`.
- `font-size-arbitrary` keeps the `conflictingClassGroupModifiers` entry with `leading`, so an arbitrary font-size **with** a line-height modifier (`text-[1.5rem]/6`) still overrides `leading`, since that form does set a line-height.

This makes `tailwind-merge` match the actual CSS Tailwind generates.

### Behavior

```ts
// arbitrary font-size no longer clobbers leading
twMerge('leading-6 text-[1.5rem]')        // 'leading-6 text-[1.5rem]'
twMerge('leading-6 text-[length:12px]')   // 'leading-6 text-[length:12px]'
twMerge('leading-6 text-(length:--s)')    // 'leading-6 text-(length:--s)'

// named font-size still clobbers leading (unchanged)
twMerge('leading-6 text-lg')              // 'text-lg'
twMerge('leading-6 text-base')            // 'text-base'

// arbitrary font-size WITH a line-height modifier still clobbers leading
twMerge('leading-6 text-[1.5rem]/6')      // 'text-[1.5rem]/6'

// named and arbitrary font-sizes still merge with each other
twMerge('text-lg text-[1.5rem]')          // 'text-[1.5rem]'
twMerge('text-[1.5rem] text-lg')          // 'text-lg'
```

## Tests

- Added regression tests in `tests/conflicts-across-class-groups.test.ts` covering: arbitrary vs named font-size against `leading`, the line-height-modifier exception, and named/arbitrary font-size still conflicting with each other.
- Updated `tests/class-map.test.ts` to include the new `font-size-arbitrary` group under the `text` first part.
- Added `'font-size-arbitrary'` to `DefaultClassGroupIds`.

All tests pass (`pnpm test`), lint is clean (`pnpm lint`), types check, and the build succeeds.

Closes #573