### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,13 +2,14 @@
 
 ## Installation
 
-The tailwind-merge package is hosted on npm under the name [`tailwind-merge`](https://www.npmjs.com/package/tailwind-merge). There are lots of package managers for installing packages hosted on npm. Here are installation instructions for the most popular ones: [npm](https://npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io) and [bun](https://bun.sh).
+The tailwind-merge package is hosted on npm under the name [`tailwind-merge`](https://www.npmjs.com/package/tailwind-merge). There are lots of package managers for installing packages hosted on npm. Here are installation instructions for the most popular ones: [npm](https://npmjs.com), [yarn](https://yarnpkg.com), [pnpm](https://pnpm.io), [bun](https://bun.sh) and [Deno](https://deno.com).
 
 ```sh
 npm add tailwind-merge
 yarn add tailwind-merge
 pnpm add tailwind-merge
 bun add tailwind-merge
+deno add tailwind-merge
 ```
 
 ## Basic usage


### PR DESCRIPTION
👋 Bartek from the Deno team here. Thanks for tailwind-merge, it's widely used across the JS ecosystem.

The Installation section lists npm / yarn / pnpm / bun. Since Deno is a drop-in replacement for npm these days, this adds a Deno line in parity, using `deno add` to match the surrounding `*-add` style:

```sh
deno add tailwind-merge
```

I also added Deno to the sentence that lists the supported package managers. Docs-only change.

Totally fine to close this if you'd rather keep the list short. Happy to adjust.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
