### PR TITLE
Default config: Keep leading-none when leading theme scale is overridden

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -1029,6 +1029,7 @@ export const getDefaultConfig = () => {
             leading: [
                 {
                     leading: [
+                        'none',
                         /** Deprecated since Tailwind CSS v4.0.0. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
                         themeLeading,
                         ...scaleUnambiguousSpacing(),

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -33,3 +33,21 @@ test('theme object can be extended', () => {
     expect(tailwindMerge('p-3 p-hello p-hallo')).toBe('p-3 p-hello p-hallo')
     expect(tailwindMerge('px-3 px-hello px-hallo')).toBe('px-hallo')
 })
+
+test('leading-none keeps merging when the leading theme scale is overridden', () => {
+    // `leading-none` is a static Tailwind v4 utility (`line-height: 1`) that does
+    // not come from the `--leading-*` theme namespace, so overriding `theme.leading`
+    // must not stop it from conflicting with other line-height utilities — same as
+    // `rounded-none` / `shadow-none` survive `theme.radius` / `theme.shadow` overrides.
+    const tailwindMerge = extendTailwindMerge({
+        override: {
+            theme: {
+                leading: ['tight'],
+            },
+        },
+    })
+
+    expect(tailwindMerge('leading-tight leading-none')).toBe('leading-none')
+    expect(tailwindMerge('leading-none leading-tight')).toBe('leading-tight')
+    expect(tailwindMerge('leading-4 leading-none')).toBe('leading-none')
+})


### PR DESCRIPTION
Closes #688.

`leading-none` is a static Tailwind v4 utility (`line-height: 1`) and is **not** part of the `--leading-*` theme namespace. But the `leading` class group only matched `none` via the deprecated `themeLeading` scale, so overriding `theme.leading` dropped `none` and orphaned `leading-none` — it stopped conflicting with any other line-height utility.

`rounded-none` / `shadow-none` / `blur-none` don't have this problem because their class groups keep `none` as a hardcoded literal (e.g. `scaleRadius()`), independent of the theme namespace.

Fix mirrors that: add `'none'` as a hardcoded literal in the `leading` class group.

```ts
const twMerge = extendTailwindMerge({ override: { theme: { leading: ['tight'] } } })
twMerge('leading-tight leading-none') // before: 'leading-tight leading-none' → after: 'leading-none'
```

Added a regression test in `tests/theme.test.ts` (fails on `main`, passes with the fix). Full suite + eslint + prettier green.