### PR TITLE
fix: hardcode leading-none as static class group value

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -1030,6 +1030,7 @@ export const getDefaultConfig = () => {
                 {
                     leading: [
                         /** Deprecated since Tailwind CSS v4.0.0. @see https://github.com/tailwindlabs/tailwindcss.com/issues/2027#issuecomment-2620152757 */
+                        'none',
                         themeLeading,
                         ...scaleUnambiguousSpacing(),
                     ],

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -18,6 +18,19 @@ test('theme scale can be extended', () => {
     )
 })
 
+test('leading-none survives theme.leading override', () => {
+    const tailwindMerge = extendTailwindMerge({
+        override: {
+            theme: {
+                leading: ['tight', 'snug'],
+            },
+        },
+    })
+
+    expect(tailwindMerge('leading-none leading-tight')).toBe('leading-tight')
+    expect(tailwindMerge('leading-none leading-tight leading-snug')).toBe('leading-snug')
+})
+
 test('theme object can be extended', () => {
     const tailwindMerge = extendTailwindMerge<never, string>({
         extend: {


### PR DESCRIPTION
### Problem

`leading-none` is a Tailwind v4 static utility that does not come from the `--leading-*` theme namespace. When a project overrides `theme.leading`, `none` drops out of the scale and `leading-none` becomes unmatched, causing it to never merge against other line-height utilities.

This is inconsistent with sibling static keywords like `rounded-none` and `shadow-none` which are hardcoded in their class groups.

### Changes

- Added `"none"` as a hardcoded literal in the leading class group definition
- Added test verifying leading-none merges correctly after theme override

Closes #688