### PR TITLE
perf: replace split with indexOf for class group extraction

### DIFF
--- a/agents/tailwind-merge-internals.md
+++ b/agents/tailwind-merge-internals.md
@@ -19,6 +19,7 @@ This file is a practical map for agent-driven changes in this repo.
    - compiles class definitions into a recursive map + validator list,
    - maps class names to class group IDs,
    - returns conflicting groups, including postfix-modifier conflicts.
+   - On the cache-miss hot path, hyphen segments are found with `indexOf`/`slice` (not `split`) so lookups avoid allocating a segment array per class.
 5. `createParseClassName` in `src/lib/parse-class-name.ts`:
    - parses stacked modifiers with bracket/paren depth tracking,
    - supports important modifier (`!`) and legacy v3 position,

--- a/src/lib/class-group-utils.ts
+++ b/src/lib/class-group-utils.ts
@@ -41,7 +41,6 @@ const createClassPartObject = (
     classGroupId,
 })
 
-const CLASS_PART_SEPARATOR = '-'
 
 const EMPTY_CONFLICTS: readonly AnyClassGroupIds[] = []
 // I use two dots here because one dot is used as prefix for class groups in plugins
@@ -56,10 +55,10 @@ export const createClassGroupUtils = (config: AnyConfig) => {
             return getGroupIdForArbitraryProperty(className)
         }
 
-        const classParts = className.split(CLASS_PART_SEPARATOR)
-        // Classes like `-inset-1` produce an empty string as first classPart. We assume that classes for negative values are used correctly and skip it.
-        const startIndex = classParts[0] === '' && classParts.length > 1 ? 1 : 0
-        return getGroupRecursive(classParts, startIndex, classMap)
+        // Classes like `-inset-1` produce an empty first segment. Skip it (same as split('-')[0] === '').
+        const startIndex = className[0] === '-' && className.length > 1 ? 1 : 0
+
+        return getGroupRecursive(className, startIndex, classMap)
     }
 
     const getConflictingClassGroupIds = (
@@ -92,20 +91,23 @@ export const createClassGroupUtils = (config: AnyConfig) => {
 }
 
 const getGroupRecursive = (
-    classParts: string[],
+    className: string,
     startIndex: number,
     classPartObject: ClassPartObject,
 ): AnyClassGroupIds | undefined => {
-    const classPathsLength = classParts.length - startIndex
-    if (classPathsLength === 0) {
+    const classNameLength = className.length
+    if (startIndex >= classNameLength) {
         return classPartObject.classGroupId
     }
 
-    const currentClassPart = classParts[startIndex]!
+    const hyphenIndex = className.indexOf('-', startIndex)
+    const partEnd = hyphenIndex === -1 ? classNameLength : hyphenIndex
+    const currentClassPart = className.slice(startIndex, partEnd)
     const nextClassPartObject = classPartObject.nextPart.get(currentClassPart)
 
     if (nextClassPartObject) {
-        const result = getGroupRecursive(classParts, startIndex + 1, nextClassPartObject)
+        const nextStartIndex = hyphenIndex === -1 ? classNameLength : hyphenIndex + 1
+        const result = getGroupRecursive(className, nextStartIndex, nextClassPartObject)
         if (result) return result
     }
 
@@ -114,11 +116,7 @@ const getGroupRecursive = (
         return undefined
     }
 
-    // Build classRest string efficiently by joining from startIndex onwards
-    const classRest =
-        startIndex === 0
-            ? classParts.join(CLASS_PART_SEPARATOR)
-            : classParts.slice(startIndex).join(CLASS_PART_SEPARATOR)
+    const classRest = className.slice(startIndex)
     const validatorsLength = validators.length
 
     for (let i = 0; i < validatorsLength; i++) {
@@ -252,11 +250,13 @@ const processObjectDefinition = (
 
 const getPart = (classPartObject: ClassPartObject, path: string): ClassPartObject => {
     let current = classPartObject
-    const parts = path.split(CLASS_PART_SEPARATOR)
-    const len = parts.length
+    let startIndex = 0
+    const pathLength = path.length
 
-    for (let i = 0; i < len; i++) {
-        const part = parts[i]!
+    while (startIndex <= pathLength) {
+        const hyphenIndex = path.indexOf('-', startIndex)
+        const partEnd = hyphenIndex === -1 ? pathLength : hyphenIndex
+        const part = path.slice(startIndex, partEnd)
 
         let next = current.nextPart.get(part)
         if (!next) {
@@ -264,6 +264,11 @@ const getPart = (classPartObject: ClassPartObject, path: string): ClassPartObjec
             current.nextPart.set(part, next)
         }
         current = next
+
+        if (hyphenIndex === -1) {
+            break
+        }
+        startIndex = hyphenIndex + 1
     }
 
     return current


### PR DESCRIPTION
## Summary

This PR optimises the cache-miss path in `getClassGroupId` by replacing `split('-')` with `indexOf` and `slice`.

**Why**: `split` allocates an array for every uncached class. Using `indexOf` avoids that allocation while keeping the code simple and relying on native methods for speed.

**Impact** (local `pnpm bench`, Node with `--expose-gc`, same machine, `main` vs this PR):

| Benchmark | main (hz) | this PR (hz) | Δ |
|-----------|-----------|--------------|---|
| simple | 3,571 | 5,227 | **+46%** |
| heavy | 3,569 | 5,018 | **+41%** |
| collection without cache | 105 | 139 | **+32%** |
| ultra long without cache | 1,067 | 1,475 | **+38%** |

Heap on cache-miss paths also dropped (e.g. collection without cache: **11.9 MB → 9.7 MB**).

Stable repeated inputs that hit the LRU cache see less difference, because `getClassGroupId` is not called again.

**Tradeoff**: The new code is slightly more imperative than the original, but it remains clear and is contained to a single hot path.

All existing tests pass.

## Details

- `getGroupRecursive` and config-build `getPart` walk hyphen segments with `indexOf`/`slice` instead of `split`
- Validator `classRest` uses `className.slice(startIndex)` instead of `slice().join('-')`
- Negative utilities (`-inset-1`) still skip the empty leading segment
- Behavior is unchanged; trie matching and validators are preserved