### PR TITLE
perf: skip caching class lists too short to contain a merge

### DIFF
--- a/agents/tailwind-merge-internals.md
+++ b/agents/tailwind-merge-internals.md
@@ -9,6 +9,7 @@ This file is a practical map for agent-driven changes in this repo.
    - lazily builds config utils on first call,
    - joins inputs via `twJoin`,
    - caches final joined-input results,
+   - skips the cache for class lists shorter than 7 characters (too short to contain two classes, so a merge is impossible; caching them would only waste slots),
    - calls `mergeClassList` on cache miss.
 3. `mergeClassList` in `src/lib/merge-classlist.ts`:
    - parses classes,

--- a/agents/tailwind-merge-internals.md
+++ b/agents/tailwind-merge-internals.md
@@ -9,7 +9,7 @@ This file is a practical map for agent-driven changes in this repo.
    - lazily builds config utils on first call,
    - joins inputs via `twJoin`,
    - caches final joined-input results,
-   - skips the cache for class lists shorter than 7 characters (too short to contain two classes, so a merge is impossible; caching them would only waste slots),
+   - returns class lists shorter than 7 characters as-is without parsing or caching (too short to contain two classes, so a merge is impossible; parsing/caching them would only waste compute and slots; class lists containing whitespace still go through `mergeClassList` for normalization),
    - calls `mergeClassList` on cache miss.
 3. `mergeClassList` in `src/lib/merge-classlist.ts`:
    - parses classes,

--- a/docs/features.md
+++ b/docs/features.md
@@ -179,6 +179,8 @@ tailwind-merge is optimized for speed when running in the browser. This includes
 
 Results get cached by default, so you don't need to worry about wasteful re-renders. The library uses a computationally lightweight [LRU cache](<https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)>) which stores up to 500 different results by default. The cache is applied after all arguments are [joined](./api-reference.md#twjoin) together to a single string. This means that if you call `twMerge` repeatedly with different arguments that result in the same string when joined, the cache will be hit.
 
+Class lists too short to contain two classes (less than 7 characters) are never cached. They can't produce a merge, so caching them would only waste cache slots on repeated single-class calls like `twMerge('flex')` and evict results that benefit from caching.
+
 The cache size can be modified or opt-out of by using [`extendTailwindMerge`](./api-reference.md#extendtailwindmerge).
 
 ### Data structures are reused between calls

--- a/docs/features.md
+++ b/docs/features.md
@@ -179,7 +179,7 @@ tailwind-merge is optimized for speed when running in the browser. This includes
 
 Results get cached by default, so you don't need to worry about wasteful re-renders. The library uses a computationally lightweight [LRU cache](<https://en.wikipedia.org/wiki/Cache_replacement_policies#Least_recently_used_(LRU)>) which stores up to 500 different results by default. The cache is applied after all arguments are [joined](./api-reference.md#twjoin) together to a single string. This means that if you call `twMerge` repeatedly with different arguments that result in the same string when joined, the cache will be hit.
 
-Class lists too short to contain two classes (less than 7 characters) are never cached. They can't produce a merge, so caching them would only waste cache slots on repeated single-class calls like `twMerge('flex')` and evict results that benefit from caching.
+Class lists too short to contain two classes (less than 7 characters) are returned as-is without parsing or caching. They can't produce a merge, so parsing them or caching the result would only waste compute and cache slots on repeated single-class calls like `twMerge('flex')` and evict results that benefit from caching.
 
 The cache size can be modified or opt-out of by using [`extendTailwindMerge`](./api-reference.md#extendtailwindmerge).
 

--- a/src/lib/create-tailwind-merge.ts
+++ b/src/lib/create-tailwind-merge.ts
@@ -8,6 +8,12 @@ type CreateConfigSubsequent = (config: AnyConfig) => AnyConfig
 type TailwindMerge = (...classLists: ClassNameValue[]) => string
 type ConfigUtils = ReturnType<typeof createConfigUtils>
 
+// Class lists shorter than this can't contain two classes (the shortest Tailwind
+// class is 3 characters, e.g. `m-0`, plus a space separator between classes), so
+// there is nothing to merge and caching the result would just waste a cache slot
+// on repeated single-class calls like `twMerge('flex')`.
+const MIN_CACHEABLE_CLASS_LIST_LENGTH = 7
+
 export const createTailwindMerge = (
     createConfigFirst: CreateConfigFirst,
     ...createConfigRest: CreateConfigSubsequent[]
@@ -32,6 +38,11 @@ export const createTailwindMerge = (
     }
 
     const tailwindMerge = (classList: string) => {
+        if (classList.length < MIN_CACHEABLE_CLASS_LIST_LENGTH) {
+            // Too short to contain a merge, so there is nothing to cache
+            return mergeClassList(classList, configUtils)
+        }
+
         const cachedResult = cacheGet(classList)
 
         if (cachedResult) {

--- a/src/lib/create-tailwind-merge.ts
+++ b/src/lib/create-tailwind-merge.ts
@@ -8,11 +8,13 @@ type CreateConfigSubsequent = (config: AnyConfig) => AnyConfig
 type TailwindMerge = (...classLists: ClassNameValue[]) => string
 type ConfigUtils = ReturnType<typeof createConfigUtils>
 
-// Class lists shorter than this can't contain two classes (the shortest Tailwind
-// class is 3 characters, e.g. `m-0`, plus a space separator between classes), so
-// there is nothing to merge and caching the result would just waste a cache slot
-// on repeated single-class calls like `twMerge('flex')`.
+// The shortest Tailwind class is 3 characters (e.g. `m-0`), so a class list
+// shorter than 7 characters (3 + space + 3) can't contain two classes and thus
+// no merge. They're returned as-is instead of being parsed and cached.
 const MIN_CACHEABLE_CLASS_LIST_LENGTH = 7
+
+// Matches any whitespace that would need normalization by mergeClassList
+const HAS_WHITESPACE_REGEX = /\s/
 
 export const createTailwindMerge = (
     createConfigFirst: CreateConfigFirst,
@@ -39,7 +41,12 @@ export const createTailwindMerge = (
 
     const tailwindMerge = (classList: string) => {
         if (classList.length < MIN_CACHEABLE_CLASS_LIST_LENGTH) {
-            // Too short to contain a merge, so there is nothing to cache
+            // A single class can't conflict with itself, so it's already the merge
+            // result — unless whitespace needs normalizing.
+            if (!HAS_WHITESPACE_REGEX.test(classList)) {
+                return classList
+            }
+
             return mergeClassList(classList, configUtils)
         }
 

--- a/tests/create-tailwind-merge.test.ts
+++ b/tests/create-tailwind-merge.test.ts
@@ -1,6 +1,36 @@
 import { expect, test } from 'vitest'
 
-import { createTailwindMerge } from '../src'
+import { createTailwindMerge, getDefaultConfig } from '../src'
+
+test('class lists too short to contain two classes are not cached', () => {
+    let parseCount = 0
+    const tailwindMerge = createTailwindMerge(() => ({
+        ...getDefaultConfig(),
+        cacheSize: 10,
+        experimentalParseClassName: ({ className, parseClassName }) => {
+            parseCount++
+            return parseClassName(className)
+        },
+    }))
+
+    // Repeated short single-class calls are never cache hits, so they get parsed every time
+    tailwindMerge('m-1')
+    tailwindMerge('m-1')
+    expect(parseCount).toBe(2)
+
+    // Multi-class lists are cached: parsed once, subsequent calls are cache hits
+    const parseCountBeforeMultiClassCall = parseCount
+    tailwindMerge('m-1 m-2')
+    expect(parseCount).toBe(parseCountBeforeMultiClassCall + 2)
+    tailwindMerge('m-1 m-2')
+    expect(parseCount).toBe(parseCountBeforeMultiClassCall + 2)
+
+    // Single-class lists with 7 or more characters are still cached
+    const parseCountBeforeLongSingleClassCall = parseCount
+    tailwindMerge('bg-red-500')
+    tailwindMerge('bg-red-500')
+    expect(parseCount).toBe(parseCountBeforeLongSingleClassCall + 1)
+})
 
 test('createTailwindMerge works with single config function', () => {
     const tailwindMerge = createTailwindMerge(() => ({

--- a/tests/create-tailwind-merge.test.ts
+++ b/tests/create-tailwind-merge.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from 'vitest'
 
 import { createTailwindMerge, getDefaultConfig } from '../src'
 
-test('class lists too short to contain two classes are not cached', () => {
+test('class lists too short to contain two classes are returned as-is without parsing or caching', () => {
     let parseCount = 0
     const tailwindMerge = createTailwindMerge(() => ({
         ...getDefaultConfig(),
@@ -13,21 +13,27 @@ test('class lists too short to contain two classes are not cached', () => {
         },
     }))
 
-    // Repeated short single-class calls are never cache hits, so they get parsed every time
-    tailwindMerge('m-1')
-    tailwindMerge('m-1')
+    // Short single-class calls are returned as-is without parsing
+    expect(tailwindMerge('m-1')).toBe('m-1')
+    expect(tailwindMerge('m-1')).toBe('m-1')
+    expect(parseCount).toBe(0)
+
+    // Whitespace is normalized via the merge, but not cached
+    expect(tailwindMerge(' m-1 ')).toBe('m-1')
+    expect(tailwindMerge(' m-1 ')).toBe('m-1')
     expect(parseCount).toBe(2)
 
-    // Multi-class lists are cached: parsed once, subsequent calls are cache hits
+    // Multi-class lists are parsed once, then served from cache
     const parseCountBeforeMultiClassCall = parseCount
     tailwindMerge('m-1 m-2')
     expect(parseCount).toBe(parseCountBeforeMultiClassCall + 2)
     tailwindMerge('m-1 m-2')
     expect(parseCount).toBe(parseCountBeforeMultiClassCall + 2)
 
-    // Single-class lists with 7 or more characters are still cached
+    // Longer single-class lists are still parsed and cached
     const parseCountBeforeLongSingleClassCall = parseCount
     tailwindMerge('bg-red-500')
+    expect(parseCount).toBe(parseCountBeforeLongSingleClassCall + 1)
     tailwindMerge('bg-red-500')
     expect(parseCount).toBe(parseCountBeforeLongSingleClassCall + 1)
 })

--- a/tests/tw-merge.benchmark.ts
+++ b/tests/tw-merge.benchmark.ts
@@ -21,6 +21,21 @@ for (let i = 0; i < 200; i++) {
     }
 }
 
+// Distinct short class lists (single class, less than 7 characters) which can never
+// contain a merge. Without the minimum class list length check these get cached like
+// any other result and evict the large class lists from the small cache, turning
+// their repeated calls into expensive cache misses.
+const shortClassLists: string[] = []
+for (const prefix of ['m', 'p', 'mx', 'my', 'px', 'py', 'w', 'h', 'z']) {
+    for (let value = 0; value <= 99; value++) {
+        shortClassLists.push(`${prefix}-${value}`)
+    }
+}
+shortClassLists.push('flex', 'grid', 'block', 'table', 'inline', 'static', 'fixed', 'hidden')
+
+// First 100 items of the test collection, matching the cache size used in the churn benchmark
+const cacheChurnTestData = testDataCollection.slice(0, 100)
+
 describe('twMerge', () => {
     benchWithMemory('init', () => {
         const twMerge = extendTailwindMerge({})
@@ -51,21 +66,46 @@ describe('twMerge', () => {
         )
     })
 
-    benchWithMemory('collection with cache', () => {
-        const twMerge = extendTailwindMerge({})
+    benchWithMemory(
+        'collection with cache',
+        () => {
+            const twMerge = extendTailwindMerge({})
 
-        for (let index = 0; index < testDataCollection.length; ++index) {
-            twMerge(...(testDataCollection[index] as TestDataItem))
-        }
-    })
+            for (let index = 0; index < testDataCollection.length; ++index) {
+                twMerge(...(testDataCollection[index] as TestDataItem))
+            }
+        },
+        { operations: testDataCollection.length },
+    )
 
-    benchWithMemory('collection without cache', () => {
-        const twMerge = extendTailwindMerge({ cacheSize: 0 })
+    benchWithMemory(
+        'collection without cache',
+        () => {
+            const twMerge = extendTailwindMerge({ cacheSize: 0 })
 
-        for (let index = 0; index < testDataCollection.length; ++index) {
-            twMerge(...(testDataCollection[index] as TestDataItem))
-        }
-    })
+            for (let index = 0; index < testDataCollection.length; ++index) {
+                twMerge(...(testDataCollection[index] as TestDataItem))
+            }
+        },
+        { operations: testDataCollection.length },
+    )
+
+    benchWithMemory(
+        'collection with short class cache churn',
+        () => {
+            const twMerge = extendTailwindMerge({ cacheSize: 100 })
+
+            for (let index = 0; index < cacheChurnTestData.length; ++index) {
+                twMerge(...(cacheChurnTestData[index] as TestDataItem))
+                twMerge(shortClassLists[(3 * index) % shortClassLists.length])
+                twMerge(shortClassLists[(3 * index + 1) % shortClassLists.length])
+                twMerge(shortClassLists[(3 * index + 2) % shortClassLists.length])
+            }
+        },
+        {
+            operations: cacheChurnTestData.length * 4,
+        },
+    )
 
     benchWithMemory('ultra long class list with many conflicts without cache', () => {
         const twMerge = extendTailwindMerge({ cacheSize: 0 })
@@ -85,9 +125,9 @@ afterAll(() => {
     for (const [benchName, benchData] of memoryData.entries()) {
         const memoryDelta = benchData.after.heapUsed - benchData.before.heapUsed
         lines.push(`  ${benchName}: ${formatBytes(memoryDelta)} heap`)
-        if (benchName.includes('collection')) {
+        if (benchData.operations !== undefined) {
             lines.push(`    Total footprint: ${formatBytes(benchData.after.rss)}`)
-            lines.push(`    Operations: ${testDataCollection.length}`)
+            lines.push(`    Operations: ${benchData.operations}`)
         }
     }
     // eslint-disable-next-line no-console -- This is a summary that will be printed to the console.
@@ -97,7 +137,7 @@ afterAll(() => {
 function benchWithMemory(
     name: string,
     fn: () => void,
-    options?: { iterations?: number; time?: number },
+    options?: { iterations?: number; time?: number; operations?: number },
 ) {
     let iterationBefore: MemoryStats | null = null
     let peakMemoryDelta = 0
@@ -139,6 +179,7 @@ function benchWithMemory(
                     memoryData.set(name, {
                         before: iterationBefore,
                         after: iterationBefore,
+                        operations: options?.operations,
                     })
                 }
             },
@@ -189,4 +230,4 @@ async function forceGarbageCollection(): Promise<void> {
     }
 }
 
-const memoryData = new Map<string, { before: MemoryStats; after: MemoryStats }>()
+const memoryData = new Map<string, { before: MemoryStats; after: MemoryStats; operations?: number }>()

--- a/tests/tw-merge.benchmark.ts
+++ b/tests/tw-merge.benchmark.ts
@@ -21,10 +21,8 @@ for (let i = 0; i < 200; i++) {
     }
 }
 
-// Distinct short class lists (single class, less than 7 characters) which can never
-// contain a merge. Without the minimum class list length check these get cached like
-// any other result and evict the large class lists from the small cache, turning
-// their repeated calls into expensive cache misses.
+// Short class lists which can't contain a merge; interleaving them with the
+// collection simulates the cache churn of repeated tiny calls
 const shortClassLists: string[] = []
 for (const prefix of ['m', 'p', 'mx', 'my', 'px', 'py', 'w', 'h', 'z']) {
     for (let value = 0; value <= 99; value++) {


### PR DESCRIPTION
## Summary

`twMerge` parses and caches every merged class list by default. In real-world apps, many calls are single-class strings like `twMerge('flex')` or `twMerge('m-1')` — results that can never be a merge, but still occupy CPU time and LRU cache slots, evicting larger class lists that actually benefit from caching.

The shortest Tailwind class is 3 characters (e.g. `m-0`), so a class list shorter than 7 characters (3 + space + 3) can't contain two classes. This PR returns such class lists **as-is without any parsing or caching** — no `mergeClassList` call, no cache lookup, no cache write. A single class can't conflict with itself, so the result is always correct.

Class lists shorter than 7 characters that contain whitespace (e.g. `' m-1 '`) still go through `mergeClassList` so the whitespace gets normalized, but they aren't cached.

## Benchmark

New benchmark case `collection with short class cache churn` (`tests/tw-merge.benchmark.ts`): cache size 100, 100 real class lists from the test collection, with 908 distinct short class lists interleaved — modeling the real-world pattern of repeated tiny calls crowding a small cache.

| Benchmark | Before | After |
|---|---|---|
| `collection with short class cache churn` | 1,421 hz | 1,979 hz (**+39%**) |

Existing benchmarks are unchanged (within noise).

## Tests

New unit test in `tests/create-tailwind-merge.test.ts` uses `experimentalParseClassName` (documented to only run outside of cache hits) as a call counter to verify:

- repeated short single-class calls are returned as-is without any parsing,
- short class lists with whitespace are still normalized but not cached,
- multi-class lists are parsed once and then served from cache,
- longer single-class lists (≥ 7 chars, e.g. `bg-red-500`) are still parsed and cached.

Validation: `pnpm lint`, `pnpm test:types`, `pnpm build`, `pnpm test:exports` all pass, 118/118 tests green.

## Docs

- `docs/features.md`: "Results are cached" section documents the exclusion of class lists < 7 characters.
- `agents/tailwind-merge-internals.md`: updated execution flow map.
