### PR TITLE
Default config: Classify deprecated `shadow-inner` into the shadow class group instead of shadow-color

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -1533,6 +1533,8 @@ export const getDefaultConfig = () => {
                     shadow: [
                         // Deprecated since Tailwind CSS v4.0.0
                         '',
+                        // Deprecated since Tailwind CSS v4.0.0
+                        'inner',
                         'none',
                         themeShadow,
                         isArbitraryVariableShadow,

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -86,6 +86,10 @@ test('supports Tailwind CSS v4.0 features', () => {
     expect(twMerge('via-red-500 via-(length:--mobile-header-gradient)')).toBe(
         'via-red-500 via-(length:--mobile-header-gradient)',
     )
+    // shadow-inner is deprecated in v4 but still sets --tw-shadow, so it conflicts with other shadow utilities and not with shadow color utilities
+    expect(twMerge('shadow-inner shadow-lg')).toBe('shadow-lg')
+    expect(twMerge('shadow-lg shadow-inner')).toBe('shadow-inner')
+    expect(twMerge('shadow-initial shadow-inner')).toBe('shadow-initial shadow-inner')
 })
 
 test('supports Tailwind CSS v4.1 features', () => {


### PR DESCRIPTION
Fixes `shadow-inner` being incorrectly classified as a color although it actually conflicts with the shadow class group.