### PR TITLE
Default config: Fix none option missing in max-h class group

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -915,7 +915,7 @@ export const getDefaultConfig = () => {
              * Max-Height
              * @see https://tailwindcss.com/docs/max-height
              */
-            'max-h': [{ 'max-h': ['screen', 'lh', ...scaleSizing()] }],
+            'max-h': [{ 'max-h': ['screen', 'lh', 'none', ...scaleSizing()] }],
 
             // ------------------
             // --- Typography ---

--- a/tests/class-group-conflicts.test.ts
+++ b/tests/class-group-conflicts.test.ts
@@ -17,6 +17,15 @@ test('merges classes from same group correctly', () => {
     expect(twMerge('gap-2 gap-px basis-px basis-3')).toBe('gap-px basis-3')
 })
 
+test('merges none values in sizing groups correctly', () => {
+    expect(twMerge('max-w-lg max-w-none')).toBe('max-w-none')
+    expect(twMerge('max-w-none max-w-lg')).toBe('max-w-lg')
+    expect(twMerge('max-h-96 max-h-none')).toBe('max-h-none')
+    expect(twMerge('max-h-none max-h-96')).toBe('max-h-96')
+    expect(twMerge('max-h-[300px] max-h-none')).toBe('max-h-none')
+    expect(twMerge('max-h-none max-h-screen')).toBe('max-h-screen')
+})
+
 test('merges classes from Font Variant Numeric section correctly', () => {
     expect(twMerge('lining-nums tabular-nums diagonal-fractions')).toBe(
         'lining-nums tabular-nums diagonal-fractions',


### PR DESCRIPTION
## Problem

`max-h-none` never wins. Not against arbitrary values, not against scale values — it is merged as if it were an unrelated class:

```js
twMerge('max-h-96 max-h-none')       // 'max-h-96 max-h-none'
twMerge('max-h-[300px] max-h-none')  // 'max-h-[300px] max-h-none'
twMerge('max-w-lg max-w-none')       // 'max-w-none'  ← the same shape, working
```

This is the exact shape of a shadcn-style component API: a base class list the component ships, plus an override the caller passes. `max-h-none` is how a caller says "drop the cap you set" — cmdk's `CommandList` ships `max-h-[300px]`, and a popover that wants the list to flex has to remove it.

What makes it hard to notice is that it usually *appears* to work. Both classes survive into the DOM, so the winner is decided by the order Tailwind emitted the two rules rather than by the caller. In the stylesheet I checked, `.max-h-[300px]` is emitted before `.max-h-none`, so the override happens to land. Nothing in the calling code says so, and a component author reading `cn(base, className)` has every reason to believe the conflict was resolved.

## Cause

`'none'` is not in the `max-h` class group:

```ts
'min-h': [{ 'min-h': ['screen', 'lh', 'none', ...scaleSizing()] }],
'max-h': [{ 'max-h': ['screen', 'lh',         ...scaleSizing()] }],
```

`scaleSizing()` is `[isFraction, 'auto', 'full', 'dvw', 'dvh', …]` and carries no `none`, so `max-h-none` matches no class group at all and is treated as a non-Tailwind class.

This isn't fallout from the v4 rewrite — `2.6.1`'s `max-h` group has no `none` either, so it goes back at least that far.

Every neighbour has it. `max-w` for the same reason this one should. `min-w` and `min-h` for a different one: Tailwind v4.0.0 briefly shipped `min-w-none`/`min-h-none`, then removed them in #15845 as invalid CSS, and the config kept them for back-compat.

## Fix

Add `'none'` to the `max-h` group.

## Scope

Unchanged: every other `max-h` value, and the important-modifier case — `max-h-[300px]` and `max-h-none!` carry different modifier signatures and still don't merge, which is correct.

Not addressed here, as an aside: `min-h`'s `'none'` is the class Tailwind removed in v4.0.1, kept the way `min-w`'s is but without the deprecation annotation `min-w` carries two entries up, so it reads as a current utility. Comment-only and not a defect, so I left it out of this diff. Happy to send it separately if you want the two entries to read alike.

## Tests

One case added to `class-group-conflicts.test.ts`, covering both orders, the arbitrary-value override, and `max-h-none` losing to a later `max-h-screen`. It includes `max-w-none` in both orders as the working control, since the whole claim is that these two should behave alike.

Full suite: 34 files, 119 tests passing. The new case fails on `main` — verified by stashing the config change and re-running, not inferred.

Prettier clean.

---

Authored with Claude Opus 5
