### PR TITLE
Default config: Fix container sizes like `inline-2xl` not merging

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -140,6 +140,7 @@ export const getDefaultConfig = () => {
         ] as const
     const scaleSizingInline = () =>
         [
+            themeContainer,
             isFraction,
             'screen',
             'full',
@@ -835,32 +836,32 @@ export const getDefaultConfig = () => {
             size: [{ size: scaleSizing() }],
             /**
              * Inline Size
-             * @see https://tailwindcss.com/docs/width
+             * @see https://tailwindcss.com/docs/inline-size
              */
             'inline-size': [{ inline: ['auto', ...scaleSizingInline()] }],
             /**
              * Min-Inline Size
-             * @see https://tailwindcss.com/docs/min-width
+             * @see https://tailwindcss.com/docs/min-inline-size
              */
             'min-inline-size': [{ 'min-inline': ['auto', ...scaleSizingInline()] }],
             /**
              * Max-Inline Size
-             * @see https://tailwindcss.com/docs/max-width
+             * @see https://tailwindcss.com/docs/max-inline-size
              */
             'max-inline-size': [{ 'max-inline': ['none', ...scaleSizingInline()] }],
             /**
              * Block Size
-             * @see https://tailwindcss.com/docs/height
+             * @see https://tailwindcss.com/docs/block-size
              */
             'block-size': [{ block: ['auto', ...scaleSizingBlock()] }],
             /**
              * Min-Block Size
-             * @see https://tailwindcss.com/docs/min-height
+             * @see https://tailwindcss.com/docs/min-block-size
              */
             'min-block-size': [{ 'min-block': ['auto', ...scaleSizingBlock()] }],
             /**
              * Max-Block Size
-             * @see https://tailwindcss.com/docs/max-height
+             * @see https://tailwindcss.com/docs/max-block-size
              */
             'max-block-size': [{ 'max-block': ['none', ...scaleSizingBlock()] }],
             /**

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -271,6 +271,9 @@ test('supports Tailwind CSS v4.2 features', () => {
     expect(twMerge('max-inline-none max-inline-10')).toBe('max-inline-10')
     expect(twMerge('min-block-auto min-block-lh min-block-10')).toBe('min-block-10')
     expect(twMerge('max-block-none max-block-lh max-block-10')).toBe('max-block-10')
+    expect(twMerge('inline-2xl inline-3xl')).toBe('inline-3xl')
+    expect(twMerge('min-inline-xs min-inline-1/2')).toBe('min-inline-1/2')
+    expect(twMerge('max-inline-svw max-inline-xl')).toBe('max-inline-xl')
 
     expect(twMerge('w-10 inline-20')).toBe('w-10 inline-20')
     expect(twMerge('h-10 block-20')).toBe('h-10 block-20')


### PR DESCRIPTION
`twMerge('inline-2xl inline-3xl')` returns `'inline-2xl inline-3xl'` instead of `'inline-3xl'`; `twMerge('max-inline-md max-inline-lg')` similarly keeps both instead of returning `'max-inline-lg'`.

**Cause:** Tailwind CSS v4.2 added `inline-*`, `min-inline-*`, and `max-inline-*` utilities using both the spacing and container namespaces. tailwind-merge's v4.2 support only included spacing values in `scaleSizingInline()`, so container sizes from `3xs` through `7xl` matched no class group and were kept as unknown classes.

**Change:** add `themeContainer` to `scaleSizingInline()`, shared by the three inline-size groups, mirroring `w`, `min-w`, and `max-w`. Tests for all three groups were added to the v4.2 block in `tests/tailwind-css-versions.test.ts`. The six logical-size `@see` comments now link to the dedicated `/docs/inline-size`, `/docs/block-size`, and min/max pages Tailwind published with v4.2, replacing the width/height links; this is comment-only.

**Not changed on purpose:** the block-size groups continue to use only spacing values, matching Tailwind and the height groups.

Found via the config-generation work on the `feature/add-tailwind-merge-configurator` branch, whose conformance sweep compares `twMerge` against Tailwind's compiled CSS. This changes merge results for affected pairs that previously kept both classes.