### PR TITLE
Default config: Fix `columns-auto` not conflicting with other `columns` classes

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -310,7 +310,15 @@ export const getDefaultConfig = () => {
              * @see https://tailwindcss.com/docs/columns
              */
             columns: [
-                { columns: [isNumber, isArbitraryValue, isArbitraryVariable, themeContainer] },
+                {
+                    columns: [
+                        isNumber,
+                        'auto',
+                        isArbitraryValue,
+                        isArbitraryVariable,
+                        themeContainer,
+                    ],
+                },
             ],
             /**
              * Break After

--- a/tests/class-group-conflicts.test.ts
+++ b/tests/class-group-conflicts.test.ts
@@ -14,6 +14,8 @@ test('merges classes from same group correctly', () => {
         twMerge('overflow-x-auto hover:overflow-x-hidden hover:overflow-x-auto overflow-x-scroll'),
     ).toBe('hover:overflow-x-auto overflow-x-scroll')
     expect(twMerge('col-span-1 col-span-full')).toBe('col-span-full')
+    expect(twMerge('columns-12 columns-auto')).toBe('columns-auto')
+    expect(twMerge('columns-auto columns-2xl')).toBe('columns-2xl')
     expect(twMerge('gap-2 gap-px basis-px basis-3')).toBe('gap-px basis-3')
 })
 


### PR DESCRIPTION
`twMerge('columns-12 columns-auto')` returns `'columns-12 columns-auto'`, but should return `'columns-auto'`.

**Cause:** `columns-auto` compiles to `columns: auto`, but the value was missing from the `columns` class group in the default config, so it was treated as an unknown class. `columns-auto` has existed since Tailwind CSS v3.0 introduced the columns utilities, making this a long-standing gap rather than a v4 regression.

**Change:** add `'auto'` to the `columns` class group, after the number validator, matching how the `z` and `order` groups list their static values. Regression tests cover both orders against numeric and container-size values. This changes affected merge results, which previously kept both classes.

Found via the config-generation work on the `feature/add-tailwind-merge-configurator` branch, whose conformance sweep compares `twMerge` against Tailwind's compiled CSS.