### PR TITLE
Default config: Fix bare `bg-conic` not merging with other background image classes

### DIFF
--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -1229,7 +1229,7 @@ export const getDefaultConfig = () => {
                                 isArbitraryValue,
                             ],
                             radial: ['', isArbitraryVariable, isArbitraryValue],
-                            conic: [isInteger, isArbitraryVariable, isArbitraryValue],
+                            conic: ['', isInteger, isArbitraryVariable, isArbitraryValue],
                         },
                         isArbitraryVariableImage,
                         isArbitraryImage,

--- a/tests/tailwind-css-versions.test.ts
+++ b/tests/tailwind-css-versions.test.ts
@@ -71,6 +71,10 @@ test('supports Tailwind CSS v4.0 features', () => {
     )
     expect(twMerge('bg-linear-to-r bg-linear-45')).toBe('bg-linear-45')
     expect(twMerge('bg-linear-to-r bg-radial-[something] bg-conic-10')).toBe('bg-conic-10')
+    expect(twMerge('bg-conic bg-conic-10')).toBe('bg-conic-10')
+    expect(twMerge('bg-conic-10 bg-conic')).toBe('bg-conic')
+    expect(twMerge('bg-radial bg-conic/decreasing')).toBe('bg-conic/decreasing')
+    expect(twMerge('bg-red-500 bg-conic')).toBe('bg-red-500 bg-conic')
     expect(twMerge('ring-4 ring-orange inset-ring inset-ring-3 inset-ring-blue')).toBe(
         'ring-4 ring-orange inset-ring-3 inset-ring-blue',
     )


### PR DESCRIPTION
`twMerge('bg-conic bg-conic-10')` returns `'bg-conic bg-conic-10'`, but should return `'bg-conic-10'`; `bg-conic/decreasing` is affected too.

**Cause:** the `bg-image` group listed `bg-conic-<angle>`, `bg-conic-(<custom-property>)`, and `bg-conic-[<value>]`, but not the value-less `bg-conic`, even though the `radial` entry already included bare `bg-radial`. The bare class therefore matched no group and was treated as unknown.

**Change:** add the bare form to the `conic` entry, mirroring `radial`. Regression tests cover conflicts with angled and radial gradients, including reverse order and the modifier form. A test also pins that a background color like `bg-red-500` still does not conflict with `bg-conic`.

Found via the config-generation work on the `feature/add-tailwind-merge-configurator` branch, whose conformance sweep compares `twMerge` against Tailwind's compiled CSS.