### PR TITLE
Default config: Support z-index theme scale in z class group

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,6 +210,7 @@ In the Tailwind config you can modify your theme variable namespace to add class
 | `--aspect-*`           | `aspect`                 |
 | `--ease-*`             | `ease`                   |
 | `--animate-*`          | `animate`                |
+| `--z-index-*`          | `z-index`                |
 
 If you modified one of the theme namespaces in your Tailwind config, you need to add the variable names to the `theme` object in tailwind-merge as well so that tailwind-merge knows about them.
 

--- a/src/lib/default-config.ts
+++ b/src/lib/default-config.ts
@@ -54,6 +54,7 @@ export const getDefaultConfig = () => {
     const themeAspect = fromTheme('aspect')
     const themeEase = fromTheme('ease')
     const themeAnimate = fromTheme('animate')
+    const themeZIndex = fromTheme('z-index')
 
     /**
      * Helpers to avoid repeating the same scales
@@ -266,6 +267,7 @@ export const getDefaultConfig = () => {
             text: [isTshirtSize],
             'text-shadow': [isTshirtSize],
             tracking: ['tighter', 'tight', 'normal', 'wide', 'wider', 'widest'],
+            'z-index': [],
         },
         classGroups: {
             // --------------
@@ -522,7 +524,7 @@ export const getDefaultConfig = () => {
              * Z-Index
              * @see https://tailwindcss.com/docs/z-index
              */
-            z: [{ z: [isInteger, 'auto', isArbitraryVariable, isArbitraryValue] }],
+            z: [{ z: [isInteger, 'auto', isArbitraryVariable, isArbitraryValue, themeZIndex] }],
 
             // ------------------------
             // --- Flexbox and Grid ---

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -224,6 +224,7 @@ export type DefaultThemeGroupIds =
     | 'text'
     | 'text-shadow'
     | 'tracking'
+    | 'z-index'
 
 /**
  * Class group IDs included in the default configuration of tailwind-merge.

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -51,3 +51,20 @@ test('leading-none keeps merging when the leading theme scale is overridden', ()
     expect(tailwindMerge('leading-none leading-tight')).toBe('leading-tight')
     expect(tailwindMerge('leading-4 leading-none')).toBe('leading-none')
 })
+
+test('z-index theme scale merges like other theme scales', () => {
+    // Tailwind CSS resolves `z-<name>` from the `--z-index-*` theme namespace,
+    // so declared values must conflict with `z-<number>` classes.
+    const tailwindMerge = extendTailwindMerge({
+        extend: {
+            theme: {
+                'z-index': ['button'],
+            },
+        },
+    })
+
+    expect(tailwindMerge('z-button z-0')).toBe('z-0')
+    expect(tailwindMerge('z-0 z-button')).toBe('z-button')
+    // values not declared in the theme must not merge
+    expect(tailwindMerge('z-unknown z-0')).toBe('z-unknown z-0')
+})


### PR DESCRIPTION
## Description
I added the `--z-index-*` theme namespace to the `z` class group via `fromTheme('z-index')`, so custom z-index values declared in the theme merge with `z-<number>` / `z-auto` / arbitrary classes, same as other theme-backed scales like `--tracking-*` or `--leading-*`.

Tailwind CSS v4 resolves `z-<name>` from the `--z-index` theme keys (`functionalUtility('z', { themeKeys: ['--z-index'] })` in utilities.ts), but the namespace ships with no default values, so the theme scale starts out empty here and only picks up values a user actually declares.

Fixes #657

## Why
The issue author declares `--z-index-button: 1` in their theme and uses `z-button z-0`. Tailwind itself understands both classes as z-index utilities, but tailwind-merge keeps them side by side because the `z` group had no theme scale, forcing a `classGroups` override for a case every other theme scale already handles.

## Verification
- before, on current `main`: with `extend: { theme: { 'z-index': ['button'] } }`, `twMerge('z-button z-0')` → `z-button z-0` (not merged)
- after: `twMerge('z-button z-0')` → `z-0`, `twMerge('z-0 z-button')` → `z-button`
- undeclared values still don't merge: `twMerge('z-unknown z-0')` → `z-unknown z-0`
- new case in `tests/theme.test.ts` fails on the pre-fix tree; full suite `pnpm test` 121/121, `pnpm lint`, `pnpm test:types` all pass