### PR TITLE
Arbitrary values: Fix color() and light-dark() being classified as lengths

### DIFF
--- a/agents/tailwind-merge-internals.md
+++ b/agents/tailwind-merge-internals.md
@@ -73,8 +73,9 @@ The hot paths are `src/lib/merge-classlist.ts` and `src/lib/class-group-utils.ts
 ## Testing strategy in this repo
 
 - Unit/behavior tests are granular by feature area in `tests/*.test.ts`.
+- Color-function regression tests should verify preservation of length utilities and replacement of other colors in `tests/colors.test.ts`.
 - `tests/tailwind-css-versions.test.ts` is the compatibility anchor for Tailwind feature coverage by version.
-- `tests/docs-examples.test.ts` enforces that documented `twMerge(...) // -> ...` examples stay correct.
+- `tests/docs-examples.test.ts` enforces that documented `twMerge(...) // -> ...` examples stay correct. Its extraction regex supports a limited set of characters (for example, `/` in arguments is excluded); verify new examples are collected and update the assertion count when adding supported examples.
 - `tests/public-api.test.ts` guards runtime exports and broad type usage.
 - `tests/tw-merge.benchmark.ts` is for performance benchmarking (`pnpm bench`), not correctness gating in CI.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -61,6 +61,12 @@ twMerge('text-[#ff0000] text-[#00ff00]') // → 'text-[#00ff00]'
 
 // Color detected by color function
 twMerge('bg-[rgb(255,0,0)] bg-[hsl(0,100%,50%)]') // → 'bg-[hsl(0,100%,50%)]'
+
+// Percentages inside color functions don't conflict with font sizes or border widths
+twMerge('text-sm text-[color(srgb_100%_0%_0%)]')
+// → 'text-sm text-[color(srgb_100%_0%_0%)]'
+twMerge('border-2 border-[light-dark(rgb(50%_0%_0%),black)]')
+// → 'border-2 border-[light-dark(rgb(50%_0%_0%),black)]'
 ```
 
 **When labels are necessary**:

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -4,7 +4,7 @@ const fractionRegex = /^\d+(?:\.\d+)?\/\d+(?:\.\d+)?$/
 const tshirtUnitRegex = /^(\d+(\.\d+)?)?(xs|sm|md|lg|xl)$/
 const lengthUnitRegex =
     /\d+(%|px|r?em|[sdl]?v([hwib]|min|max)|pt|pc|in|cm|mm|cap|ch|ex|r?lh|cq(w|h|i|b|min|max))|\b(calc|min|max|clamp)\(.+\)|^0$/
-const colorFunctionRegex = /^(rgba?|hsla?|hwb|(ok)?(lab|lch)|color-mix)\(.+\)$/
+const colorFunctionRegex = /^(rgba?|hsla?|hwb|(ok)?(lab|lch)|color-mix|color|light-dark)\(.+\)$/
 // Shadow always begins with x and y offset separated by underscore optionally prepended by inset
 const shadowRegex = /^(inset_)?-?((\d+)?\.?(\d+)[a-z]+|0)_-?((\d+)?\.?(\d+)[a-z]+|0)/
 const imageRegex =

--- a/tests/colors.test.ts
+++ b/tests/colors.test.ts
@@ -9,3 +9,53 @@ test('handles color conflicts properly', () => {
         'stroke-[hsl(350_80%_0%)] stroke-[10px]',
     )
 })
+
+test('handles color() functions with percentages correctly', () => {
+    expect(twMerge('text-sm text-[color(display-p3_1_0_0/50%)]')).toBe(
+        'text-sm text-[color(display-p3_1_0_0/50%)]',
+    )
+    expect(twMerge('text-[color(display-p3_1_0_0/50%)] text-sm')).toBe(
+        'text-[color(display-p3_1_0_0/50%)] text-sm',
+    )
+    expect(twMerge('text-red-500 text-[color(display-p3_1_0_0/50%)]')).toBe(
+        'text-[color(display-p3_1_0_0/50%)]',
+    )
+    expect(twMerge('text-[color(display-p3_1_0_0/50%)] text-red-500')).toBe('text-red-500')
+    expect(twMerge('border-2 border-[color(display-p3_1_0_0/50%)]')).toBe(
+        'border-2 border-[color(display-p3_1_0_0/50%)]',
+    )
+    expect(twMerge('border-[color(display-p3_1_0_0/50%)] border-2')).toBe(
+        'border-[color(display-p3_1_0_0/50%)] border-2',
+    )
+    expect(twMerge('stroke-2 stroke-[color(display-p3_1_0_0/50%)]')).toBe(
+        'stroke-2 stroke-[color(display-p3_1_0_0/50%)]',
+    )
+    expect(twMerge('stroke-[color(display-p3_1_0_0/50%)] stroke-2')).toBe(
+        'stroke-[color(display-p3_1_0_0/50%)] stroke-2',
+    )
+})
+
+test('handles light-dark() functions with percentages correctly', () => {
+    expect(twMerge('text-sm text-[light-dark(white,rgb(0_0_0/50%))]')).toBe(
+        'text-sm text-[light-dark(white,rgb(0_0_0/50%))]',
+    )
+    expect(twMerge('text-[light-dark(white,rgb(0_0_0/50%))] text-sm')).toBe(
+        'text-[light-dark(white,rgb(0_0_0/50%))] text-sm',
+    )
+    expect(twMerge('text-red-500 text-[light-dark(white,rgb(0_0_0/50%))]')).toBe(
+        'text-[light-dark(white,rgb(0_0_0/50%))]',
+    )
+    expect(twMerge('text-[light-dark(white,rgb(0_0_0/50%))] text-red-500')).toBe('text-red-500')
+    expect(twMerge('border-2 border-[light-dark(white,rgb(0_0_0/50%))]')).toBe(
+        'border-2 border-[light-dark(white,rgb(0_0_0/50%))]',
+    )
+    expect(twMerge('border-[light-dark(white,rgb(0_0_0/50%))] border-2')).toBe(
+        'border-[light-dark(white,rgb(0_0_0/50%))] border-2',
+    )
+    expect(twMerge('stroke-2 stroke-[light-dark(white,rgb(0_0_0/50%))]')).toBe(
+        'stroke-2 stroke-[light-dark(white,rgb(0_0_0/50%))]',
+    )
+    expect(twMerge('stroke-[light-dark(white,rgb(0_0_0/50%))] stroke-2')).toBe(
+        'stroke-[light-dark(white,rgb(0_0_0/50%))] stroke-2',
+    )
+})

--- a/tests/docs-examples.test.ts
+++ b/tests/docs-examples.test.ts
@@ -9,7 +9,7 @@ const twMergeExampleRegex =
     /twMerge\((?<arguments>[\w\s\-:[\]#(),!&%\n'"]+?)\)(?!.*(?<!\/\/.*)')\s*\n?\s*\/\/\s*→\s*['"](?<result>.+)['"]/g
 
 test('docs examples', () => {
-    expect.assertions(61)
+    expect.assertions(63)
 
     return forEachFile(['README.md', 'docs/**/*.md'], (fileContent) => {
         Array.from(fileContent.matchAll(twMergeExampleRegex)).forEach((match) => {

--- a/tests/validators.test.ts
+++ b/tests/validators.test.ts
@@ -111,6 +111,8 @@ test('isArbitraryLength', () => {
     expect(isArbitraryLength('[12px')).toBe(false)
     expect(isArbitraryLength('12px]')).toBe(false)
     expect(isArbitraryLength('one')).toBe(false)
+    expect(isArbitraryLength('[color(display-p3_1_0_0/50%)]')).toBe(false)
+    expect(isArbitraryLength('[light-dark(white,rgb(0_0_0/50%))]')).toBe(false)
 })
 
 test('isArbitraryNumber', () => {


### PR DESCRIPTION
Fixes #710

`twMerge('text-sm text-[color(display-p3_1_0_0/50%)]')` removes `text-sm` because the percentage inside the color is mistaken for a length. The same issue affects `light-dark()` and other prefixes shared by colors and lengths, including border and stroke utilities.

Add `color` and `light-dark` to the existing `colorFunctionRegex` exclusion used by `isLengthOnly`, following the treatment of `color-mix()` in #591. This preserves unrelated size utilities and correctly resolves color-to-color conflicts. The fix covers lowercase function names and retains the existing case-sensitive matching behavior.

Regression tests cover both class orders, text-color replacement, and preservation of font size, border width, and stroke width. Two documentation examples are included in the existing example test, and relevant testing guidance is updated.

Validation:

- Against unmodified source: **4 failing tests** across the color, validator, and documentation tests. With the fix: **34 test files / 122 tests pass** with coverage.
- `pnpm lint`, `pnpm test:types`, `pnpm build`, and `pnpm test:exports` pass, including TypeScript 3.8 declaration compatibility.
- Changed TypeScript files pass the repository's Prettier configuration.
- Verified generated color declarations with Tailwind 4.0.0, 4.1.17, 4.2.0, and 4.3.0.